### PR TITLE
Add Indonesian translation

### DIFF
--- a/lib/data/id/agreeableness.js
+++ b/lib/data/id/agreeableness.js
@@ -1,0 +1,104 @@
+module.exports = {
+  domain: 'A',
+  title: 'Agreeableness',
+  shortDescription: 'Agreeableness reflects individual differences in concern with cooperation and social harmony. Agreeable individuals value getting along with others.',
+  description: `They are therefore considerate, friendly,
+generous, helpful, and willing to compromise their interests with
+others'. Agreeable people also have an optimistic view of human
+nature. They believe people are basically honest, decent, and
+trustworthy. <br /><br />
+Disagreeable individuals place self-interest above getting along with
+others.  They are generally unconcerned with others' well-being, and
+therefore are unlikely to extend themselves for other people.
+Sometimes their skepticism about others' motives causes them to be
+suspicious, unfriendly, and uncooperative.
+<br /><br />
+Agreeableness is obviously advantageous for attaining and maintaining
+popularity. Agreeable people are better liked than disagreeable
+people. On the other hand, agreeableness is not useful in situations
+that require tough or absolute objective decisions. Disagreeable
+people can make excellent scientists, critics, or soldiers.`,
+  results: [
+    {
+      score: 'low', // do not translate this line
+      text: `Your score on Agreeableness is low, indicating less concern
+with others' needs than with your own. People see you as tough,
+critical, and uncompromising.`
+    },
+    {
+      score: 'neutral', // do not translate this line
+      text: `Your level of Agreeableness is average, indicating some concern
+with others' Needs, but, generally, unwillingness to sacrifice
+yourself for others.`
+    },
+    {
+      score: 'high', // do not translate this line
+      text: `Your high level of Agreeableness indicates a strong interest in
+others' needs and well-being. You are pleasant, sympathetic, and
+cooperative.`
+    }
+  ],
+  facets: [
+    {
+      facet: 1,
+      title: 'Trust',
+      text: `A person with high trust assumes that most people
+are fair, honest, and have good intentions. Persons low in trust
+see others as selfish, devious, and potentially dangerous.`
+    },
+    {
+      facet: 2,
+      title: 'Morality',
+      text: `High scorers on this scale see no need for
+pretense or manipulation when dealing with others and are therefore
+candid, frank, and sincere. Low scorers believe that a certain
+amount of deception in social relationships is necessary. People
+find it relatively easy to relate to the straightforward
+high-scorers on this scale. They generally find it more difficult
+to relate to the unstraightforward low-scorers on this scale. It
+should be made clear that low scorers are not unprincipled
+or immoral; they are simply more guarded and less willing to openly
+reveal the whole truth.`
+    },
+    {
+      facet: 3,
+      title: 'Altruism',
+      text: `Altruistic people find helping other people
+genuinely rewarding. Consequently, they are generally willing to
+assist those who are in need. Altruistic people find that doing
+things for others is a form of self-fulfillment rather than
+self-sacrifice. Low scorers on this scale do not particularly like
+helping those in need. Requests for help feel like an imposition
+rather than an opportunity for self-fulfillment.`
+    },
+    {
+      facet: 4,
+      title: 'Cooperation',
+      text: `Individuals who score high on this scale
+dislike confrontations. They are perfectly willing to compromise or
+to deny their own needs in order to get along with others. Those
+who score low on this scale are more likely to intimidate others to
+get their way.`
+    },
+    {
+      facet: 5,
+      title: 'Modesty',
+      text: `High scorers on this scale do not like to claim
+that they are better than other people. In some cases this attitude
+may derive from low self-confidence or self-esteem. Nonetheless,
+some people with high self-esteem find immodesty unseemly. Those
+who are willing to describe themselves as superior tend to
+be seen as disagreeably arrogant by other people.`
+    },
+    {
+      facet: 6,
+      title: 'Sympathy',
+      text: `People who score high on this scale are
+tenderhearted and compassionate. They feel the pain of others
+vicariously and are easily moved to pity. Low scorers are not
+affected strongly by human suffering. They pride themselves on
+making objective judgments based on reason. They are more concerned
+with truth and impartial justice than with mercy.`
+    }
+  ]
+}

--- a/lib/data/id/agreeableness.js
+++ b/lib/data/id/agreeableness.js
@@ -23,17 +23,17 @@ module.exports = {
     {
       facet: 1,
       title: 'Kepercayaan',
-      text: `A person with high trust assumes that most people are fair, honest, and have good intentions. Persons low in trust see others as selfish, devious, and potentially dangerous.`
+      text: `Seseorang dengan tingkat kepercayaan yang tinggi menganggap bahwa kebanyakan orang adil, jujur, dan mendapat niat baik. Orang yang kurang percaya melihat orang lain sebagai egois, licik, dan berpotensi berbahaya.`
     },
     {
       facet: 2,
       title: 'Moralitas',
-      text: `Orang-orang yang memiliki nilai tinggi pada skala ini melihat ketidakperluan untuk berpura-pura atau manipulasi ketika berhadapan dengan orang lain, sehingga mereka jujur dan tulus. Orang-orang yang memiliki nilai rendah percaya bahwa didalam hubungan sosial diperlukan sejumlah penipuan. Orang-orang merasa relatif mudah untuk berhubungan langsung dengan para pemilik nilai tinggi pada skala ini. Mereka umumnya merasa lebih sulit untuk berhubungan dengan orang-orang yang memiliki nilai rendah dalam skala ini. Harus dijelaskan bahwa orang-orang yang memiliki nilai rendah bukanlah tidak berprinsip atau tidak bermoral; mereka hanya lebih berjaga dan kurang bersedia untuk mengungkapkan seluruh kebenaran secara terbuka.`
+      text: `Orang-orang yang mendapat nilai tinggi pada skala ini melihat ketidakperluan untuk berpura-pura atau manipulasi ketika berhadapan dengan orang lain, sehingga mereka jujur dan tulus. Orang-orang yang mendapat nilai rendah percaya bahwa didalam hubungan sosial diperlukan sejumlah penipuan. Orang-orang merasa relatif mudah untuk berhubungan langsung dengan para pemilik nilai tinggi pada skala ini. Mereka umumnya merasa lebih sulit untuk berhubungan dengan orang-orang yang mendapat nilai rendah dalam skala ini. Harus dijelaskan bahwa orang-orang yang mendapat nilai rendah bukanlah tidak berprinsip atau tidak bermoral; mereka hanya lebih berjaga dan kurang bersedia untuk mengungkapkan seluruh kebenaran secara terbuka.`
     },
     {
       facet: 3,
       title: 'Alturisme',
-      text: `Orang yang altruistik merasa bahwa membantu orang lain benar-benar bermanfaat. Akibatnya, mereka umumnya bersedia membantu mereka yang membutuhkan. Orang altruistik menemukan bahwa melakukan sesuatu untuk orang lain adalah bentuk pemenuhan diri daripada pengorbanan diri. Orang-orang yang memiliki nilai rendah pada skala ini tidak terlalu suka membantu mereka yang membutuhkan. Mereka merasa permintaan bantuan adalah sebuah pemaksaan daripada sebuah kesempatan untuk pemenuhan diri. `
+      text: `Orang yang altruistik merasa bahwa membantu orang lain benar-benar bermanfaat. Akibatnya, mereka umumnya bersedia membantu mereka yang membutuhkan. Orang altruistik menemukan bahwa melakukan sesuatu untuk orang lain adalah bentuk pemenuhan diri daripada pengorbanan diri. Orang-orang yang mendapat nilai rendah pada skala ini tidak terlalu suka membantu mereka yang membutuhkan. Mereka merasa permintaan bantuan adalah sebuah pemaksaan daripada sebuah kesempatan untuk pemenuhan diri. `
     },
     {
       facet: 4,
@@ -43,7 +43,7 @@ module.exports = {
     {
       facet: 5,
       title: 'Kesopanan',
-      text: `Orang-orang yang memiliki nilai tinggi pada skala ini tidak suka mengklaim bahwa mereka lebih baik dari orang lain. Dalam beberapa kasus sikap ini mungkin berasal dari rendahnya kepercayaan diri atau harga diri. Meskipun demikian, beberapa orang dengan harga diri yang tinggi menganggap ketidaksopanan sebagai hal yang tidak pantas. Mereka yang bersedia menggambarkan diri mereka sebagai superior cenderung dianggap arogan oleh orang lain. `
+      text: `Orang-orang yang mendapat nilai tinggi pada skala ini tidak suka mengklaim bahwa mereka lebih baik dari orang lain. Dalam beberapa kasus sikap ini mungkin berasal dari rendahnya kepercayaan diri atau harga diri. Meskipun demikian, beberapa orang dengan harga diri yang tinggi menganggap ketidaksopanan sebagai hal yang tidak pantas. Mereka yang bersedia menggambarkan diri mereka sebagai superior cenderung dianggap arogan oleh orang lain. `
     },
     {
       facet: 6,

--- a/lib/data/id/agreeableness.js
+++ b/lib/data/id/agreeableness.js
@@ -8,47 +8,47 @@ module.exports = {
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Nilai Anda pada Kepersetujuan rendah, yang menunjukkan perhatian terhadap kebutuhan orang lain lebih kecil dibandingkan dengan kebutuhan sendiri. Orang-orang melihat Anda sebagai sosok yang tangguh, kritis, dan tanpa kompromi.`
+      text: 'Nilai Anda pada Kepersetujuan rendah, yang menunjukkan perhatian terhadap kebutuhan orang lain lebih kecil dibandingkan dengan kebutuhan sendiri. Orang-orang melihat Anda sebagai sosok yang tangguh, kritis, dan tanpa kompromi.'
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Tingkat Kepersetujuan Anda rata-rata, menunjukkan beberapa perhatian dengan Kebutuhan orang lain, tetapi, umumnya, keengganan untuk mengorbankan diri Anda untuk orang lain.`
+      text: 'Tingkat Kepersetujuan Anda rata-rata, menunjukkan beberapa perhatian dengan Kebutuhan orang lain, tetapi, umumnya, keengganan untuk mengorbankan diri Anda untuk orang lain.'
     },
     {
       score: 'high', // do not translate this line
-      text: `Tingkat Kepersetujuan Anda yang tinggi menunjukkan minat yang kuat pada kebutuhan dan kesejahteraan orang lain. Anda menyenangkan, simpatik, dan kooperatif.`
+      text: 'Tingkat Kepersetujuan Anda yang tinggi menunjukkan minat yang kuat pada kebutuhan dan kesejahteraan orang lain. Anda menyenangkan, simpatik, dan kooperatif.'
     }
   ],
   facets: [
     {
       facet: 1,
       title: 'Kepercayaan',
-      text: `Seseorang dengan tingkat kepercayaan yang tinggi menganggap bahwa kebanyakan orang adil, jujur, dan mendapat niat baik. Orang yang kurang percaya melihat orang lain sebagai egois, licik, dan berpotensi berbahaya.`
+      text: 'Seseorang dengan tingkat kepercayaan yang tinggi menganggap bahwa kebanyakan orang adil, jujur, dan mendapat niat baik. Orang yang kurang percaya melihat orang lain sebagai egois, licik, dan berpotensi berbahaya.'
     },
     {
       facet: 2,
       title: 'Moralitas',
-      text: `Orang-orang yang mendapat nilai tinggi pada skala ini melihat ketidakperluan untuk berpura-pura atau manipulasi ketika berhadapan dengan orang lain, sehingga mereka jujur dan tulus. Orang-orang yang mendapat nilai rendah percaya bahwa didalam hubungan sosial diperlukan sejumlah penipuan. Orang-orang merasa relatif mudah untuk berhubungan langsung dengan para pemilik nilai tinggi pada skala ini. Mereka umumnya merasa lebih sulit untuk berhubungan dengan orang-orang yang mendapat nilai rendah dalam skala ini. Harus dijelaskan bahwa orang-orang yang mendapat nilai rendah bukanlah tidak berprinsip atau tidak bermoral; mereka hanya lebih berjaga dan kurang bersedia untuk mengungkapkan seluruh kebenaran secara terbuka.`
+      text: 'Orang-orang yang mendapat nilai tinggi pada skala ini melihat ketidakperluan untuk berpura-pura atau manipulasi ketika berhadapan dengan orang lain, sehingga mereka jujur dan tulus. Orang-orang yang mendapat nilai rendah percaya bahwa didalam hubungan sosial diperlukan sejumlah penipuan. Orang-orang merasa relatif mudah untuk berhubungan langsung dengan para pemilik nilai tinggi pada skala ini. Mereka umumnya merasa lebih sulit untuk berhubungan dengan orang-orang yang mendapat nilai rendah dalam skala ini. Harus dijelaskan bahwa orang-orang yang mendapat nilai rendah bukanlah tidak berprinsip atau tidak bermoral; mereka hanya lebih berjaga dan kurang bersedia untuk mengungkapkan seluruh kebenaran secara terbuka.'
     },
     {
       facet: 3,
       title: 'Alturisme',
-      text: `Orang yang altruistik merasa bahwa membantu orang lain benar-benar bermanfaat. Akibatnya, mereka umumnya bersedia membantu mereka yang membutuhkan. Orang altruistik menemukan bahwa melakukan sesuatu untuk orang lain adalah bentuk pemenuhan diri daripada pengorbanan diri. Orang-orang yang mendapat nilai rendah pada skala ini tidak terlalu suka membantu mereka yang membutuhkan. Mereka merasa permintaan bantuan adalah sebuah pemaksaan daripada sebuah kesempatan untuk pemenuhan diri. `
+      text: 'Orang yang altruistik merasa bahwa membantu orang lain benar-benar bermanfaat. Akibatnya, mereka umumnya bersedia membantu mereka yang membutuhkan. Orang altruistik menemukan bahwa melakukan sesuatu untuk orang lain adalah bentuk pemenuhan diri daripada pengorbanan diri. Orang-orang yang mendapat nilai rendah pada skala ini tidak terlalu suka membantu mereka yang membutuhkan. Mereka merasa permintaan bantuan adalah sebuah pemaksaan daripada sebuah kesempatan untuk pemenuhan diri. '
     },
     {
       facet: 4,
       title: 'Kooperasi',
-      text: `Individu yang mendapat nilai tinggi pada skala ini tidak menyukai konfrontasi. Mereka sangat bersedia untuk berkompromi atau menyangkal kebutuhan mereka sendiri untuk bergaul dengan orang lain. Mereka yang mendapat nilai rendah pada skala ini lebih cenderung mengintimidasi orang lain untuk mendapatkan apa yang mereka inginkan.`
+      text: 'Individu yang mendapat nilai tinggi pada skala ini tidak menyukai konfrontasi. Mereka sangat bersedia untuk berkompromi atau menyangkal kebutuhan mereka sendiri untuk bergaul dengan orang lain. Mereka yang mendapat nilai rendah pada skala ini lebih cenderung mengintimidasi orang lain untuk mendapatkan apa yang mereka inginkan.'
     },
     {
       facet: 5,
       title: 'Kesopanan',
-      text: `Orang-orang yang mendapat nilai tinggi pada skala ini tidak suka mengklaim bahwa mereka lebih baik dari orang lain. Dalam beberapa kasus sikap ini mungkin berasal dari rendahnya kepercayaan diri atau harga diri. Meskipun demikian, beberapa orang dengan harga diri yang tinggi menganggap ketidaksopanan sebagai hal yang tidak pantas. Mereka yang bersedia menggambarkan diri mereka sebagai superior cenderung dianggap arogan oleh orang lain. `
+      text: 'Orang-orang yang mendapat nilai tinggi pada skala ini tidak suka mengklaim bahwa mereka lebih baik dari orang lain. Dalam beberapa kasus sikap ini mungkin berasal dari rendahnya kepercayaan diri atau harga diri. Meskipun demikian, beberapa orang dengan harga diri yang tinggi menganggap ketidaksopanan sebagai hal yang tidak pantas. Mereka yang bersedia menggambarkan diri mereka sebagai superior cenderung dianggap arogan oleh orang lain. '
     },
     {
       facet: 6,
       title: 'Simpati',
-      text: `Orang-orang yang mendapat nilai tinggi pada skala ini berhati lembut dan penuh kasih sayang. Mereka merasakan penderitaan orang lain secara perwakilan dan mudah tergerak untuk kasihan. Orang-orang yang mendapat nilai rendah tidak terlalu terpengaruh oleh penderitaan manusia. Mereka bangga membuat penilaian objektif yang berdasar alasan. Mereka lebih mementingkan kebenaran dan keadilan yang tidak memihak daripada belas kasihan.`
+      text: 'Orang-orang yang mendapat nilai tinggi pada skala ini berhati lembut dan penuh kasih sayang. Mereka merasakan penderitaan orang lain secara perwakilan dan mudah tergerak untuk kasihan. Orang-orang yang mendapat nilai rendah tidak terlalu terpengaruh oleh penderitaan manusia. Mereka bangga membuat penilaian objektif yang berdasar alasan. Mereka lebih mementingkan kebenaran dan keadilan yang tidak memihak daripada belas kasihan.'
     }
   ]
 }

--- a/lib/data/id/agreeableness.js
+++ b/lib/data/id/agreeableness.js
@@ -1,104 +1,54 @@
 module.exports = {
   domain: 'A',
-  title: 'Agreeableness',
-  shortDescription: 'Agreeableness reflects individual differences in concern with cooperation and social harmony. Agreeable individuals value getting along with others.',
-  description: `They are therefore considerate, friendly,
-generous, helpful, and willing to compromise their interests with
-others'. Agreeable people also have an optimistic view of human
-nature. They believe people are basically honest, decent, and
-trustworthy. <br /><br />
-Disagreeable individuals place self-interest above getting along with
-others.  They are generally unconcerned with others' well-being, and
-therefore are unlikely to extend themselves for other people.
-Sometimes their skepticism about others' motives causes them to be
-suspicious, unfriendly, and uncooperative.
-<br /><br />
-Agreeableness is obviously advantageous for attaining and maintaining
-popularity. Agreeable people are better liked than disagreeable
-people. On the other hand, agreeableness is not useful in situations
-that require tough or absolute objective decisions. Disagreeable
-people can make excellent scientists, critics, or soldiers.`,
+  title: 'Kepersetujuan',
+  shortDescription: 'Kepersetujuan mencerminkan perbedaan individu dalam hal kerjasama dan harmoni sosial. Individu yang bersetuju menghargai bergaul dengan orang lain.',
+  description: `Mereka jadinya penuh perhatian, ramah, murah hati, suka membantu, dan bersedia berkompromi dengan kepentingan orang lain. Orang yang bersetuju juga memiliki pandangan optimis tentang sifat manusia. Mereka percaya bahwa orang pada dasarnya jujur, sopan, dan dapat dipercaya. <br /><br /> 
+  Individu yang tidak bersetuju menempatkan kepentingan pribadi di atas bergaul dengan orang lain. Mereka umumnya tidak peduli dengan kesejahteraan orang lain, dan karena itu tidak mungkin untuk memperluas diri mereka untuk orang lain. Terkadang skeptisisme mereka tentang motif orang lain menyebabkan mereka curiga, tidak ramah, dan tidak kooperatif.<br /><br />
+  Kepersetujuan jelas menguntungkan untuk mendapatkan dan mempertahankan popularitas. Orang yang bersetuju lebih disukai daripada orang yang tidak menyenangkan. Di sisi lain, kepersetujuan tidak berguna dalam situasi yang membutuhkan keputusan objektif yang keras atau mutlak. Orang yang tidak bersetuju bisa menjadi ilmuwan, kritikus, atau tentara yang hebat.`,
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Your score on Agreeableness is low, indicating less concern
-with others' needs than with your own. People see you as tough,
-critical, and uncompromising.`
+      text: `Nilai Anda pada Kepersetujuan rendah, yang menunjukkan perhatian terhadap kebutuhan orang lain lebih kecil dibandingkan dengan kebutuhan sendiri. Orang-orang melihat Anda sebagai sosok yang tangguh, kritis, dan tanpa kompromi.`
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Your level of Agreeableness is average, indicating some concern
-with others' Needs, but, generally, unwillingness to sacrifice
-yourself for others.`
+      text: `Tingkat Kepersetujuan Anda rata-rata, menunjukkan beberapa perhatian dengan Kebutuhan orang lain, tetapi, umumnya, keengganan untuk mengorbankan diri Anda untuk orang lain.`
     },
     {
       score: 'high', // do not translate this line
-      text: `Your high level of Agreeableness indicates a strong interest in
-others' needs and well-being. You are pleasant, sympathetic, and
-cooperative.`
+      text: `Tingkat Kepersetujuan Anda yang tinggi menunjukkan minat yang kuat pada kebutuhan dan kesejahteraan orang lain. Anda menyenangkan, simpatik, dan kooperatif.`
     }
   ],
   facets: [
     {
       facet: 1,
-      title: 'Trust',
-      text: `A person with high trust assumes that most people
-are fair, honest, and have good intentions. Persons low in trust
-see others as selfish, devious, and potentially dangerous.`
+      title: 'Kepercayaan',
+      text: `A person with high trust assumes that most people are fair, honest, and have good intentions. Persons low in trust see others as selfish, devious, and potentially dangerous.`
     },
     {
       facet: 2,
-      title: 'Morality',
-      text: `High scorers on this scale see no need for
-pretense or manipulation when dealing with others and are therefore
-candid, frank, and sincere. Low scorers believe that a certain
-amount of deception in social relationships is necessary. People
-find it relatively easy to relate to the straightforward
-high-scorers on this scale. They generally find it more difficult
-to relate to the unstraightforward low-scorers on this scale. It
-should be made clear that low scorers are not unprincipled
-or immoral; they are simply more guarded and less willing to openly
-reveal the whole truth.`
+      title: 'Moralitas',
+      text: `Orang-orang yang memiliki nilai tinggi pada skala ini melihat ketidakperluan untuk berpura-pura atau manipulasi ketika berhadapan dengan orang lain, sehingga mereka jujur dan tulus. Orang-orang yang memiliki nilai rendah percaya bahwa didalam hubungan sosial diperlukan sejumlah penipuan. Orang-orang merasa relatif mudah untuk berhubungan langsung dengan para pemilik nilai tinggi pada skala ini. Mereka umumnya merasa lebih sulit untuk berhubungan dengan orang-orang yang memiliki nilai rendah dalam skala ini. Harus dijelaskan bahwa orang-orang yang memiliki nilai rendah bukanlah tidak berprinsip atau tidak bermoral; mereka hanya lebih berjaga dan kurang bersedia untuk mengungkapkan seluruh kebenaran secara terbuka.`
     },
     {
       facet: 3,
-      title: 'Altruism',
-      text: `Altruistic people find helping other people
-genuinely rewarding. Consequently, they are generally willing to
-assist those who are in need. Altruistic people find that doing
-things for others is a form of self-fulfillment rather than
-self-sacrifice. Low scorers on this scale do not particularly like
-helping those in need. Requests for help feel like an imposition
-rather than an opportunity for self-fulfillment.`
+      title: 'Alturisme',
+      text: `Orang yang altruistik merasa bahwa membantu orang lain benar-benar bermanfaat. Akibatnya, mereka umumnya bersedia membantu mereka yang membutuhkan. Orang altruistik menemukan bahwa melakukan sesuatu untuk orang lain adalah bentuk pemenuhan diri daripada pengorbanan diri. Orang-orang yang memiliki nilai rendah pada skala ini tidak terlalu suka membantu mereka yang membutuhkan. Mereka merasa permintaan bantuan adalah sebuah pemaksaan daripada sebuah kesempatan untuk pemenuhan diri. `
     },
     {
       facet: 4,
-      title: 'Cooperation',
-      text: `Individuals who score high on this scale
-dislike confrontations. They are perfectly willing to compromise or
-to deny their own needs in order to get along with others. Those
-who score low on this scale are more likely to intimidate others to
-get their way.`
+      title: 'Kooperasi',
+      text: `Individu yang mendapat nilai tinggi pada skala ini tidak menyukai konfrontasi. Mereka sangat bersedia untuk berkompromi atau menyangkal kebutuhan mereka sendiri untuk bergaul dengan orang lain. Mereka yang mendapat nilai rendah pada skala ini lebih cenderung mengintimidasi orang lain untuk mendapatkan apa yang mereka inginkan.`
     },
     {
       facet: 5,
-      title: 'Modesty',
-      text: `High scorers on this scale do not like to claim
-that they are better than other people. In some cases this attitude
-may derive from low self-confidence or self-esteem. Nonetheless,
-some people with high self-esteem find immodesty unseemly. Those
-who are willing to describe themselves as superior tend to
-be seen as disagreeably arrogant by other people.`
+      title: 'Kesopanan',
+      text: `Orang-orang yang memiliki nilai tinggi pada skala ini tidak suka mengklaim bahwa mereka lebih baik dari orang lain. Dalam beberapa kasus sikap ini mungkin berasal dari rendahnya kepercayaan diri atau harga diri. Meskipun demikian, beberapa orang dengan harga diri yang tinggi menganggap ketidaksopanan sebagai hal yang tidak pantas. Mereka yang bersedia menggambarkan diri mereka sebagai superior cenderung dianggap arogan oleh orang lain. `
     },
     {
       facet: 6,
-      title: 'Sympathy',
-      text: `People who score high on this scale are
-tenderhearted and compassionate. They feel the pain of others
-vicariously and are easily moved to pity. Low scorers are not
-affected strongly by human suffering. They pride themselves on
-making objective judgments based on reason. They are more concerned
-with truth and impartial justice than with mercy.`
+      title: 'Simpati',
+      text: `Orang-orang yang mendapat nilai tinggi pada skala ini berhati lembut dan penuh kasih sayang. Mereka merasakan penderitaan orang lain secara perwakilan dan mudah tergerak untuk kasihan. Orang-orang yang mendapat nilai rendah tidak terlalu terpengaruh oleh penderitaan manusia. Mereka bangga membuat penilaian objektif yang berdasar alasan. Mereka lebih mementingkan kebenaran dan keadilan yang tidak memihak daripada belas kasihan.`
     }
   ]
 }

--- a/lib/data/id/conscientiousness.js
+++ b/lib/data/id/conscientiousness.js
@@ -1,0 +1,133 @@
+module.exports = {
+  domain: 'C',
+  title: 'Conscientiousness',
+  shortDescription: 'Conscientiousness concerns the way in which we control, regulate, and direct our impulses.',
+  description: `Impulses are not inherently bad;
+occasionally time constraints require a snap decision, and acting on
+our first impulse can be an effective response. Also, in times of
+play rather than work, acting spontaneously and impulsively can be
+fun. Impulsive individuals can be seen by others as colorful,
+fun-to-be-with, and zany.
+<br /><br />
+Nonetheless, acting on impulse can lead to trouble in a number of
+ways. Some impulses are antisocial. Uncontrolled antisocial acts
+not only harm other members of society, but also can result in
+retribution toward the perpetrator of such impulsive acts. Another
+problem with impulsive acts is that they often produce immediate
+rewards but undesirable, long-term consequences. Examples include
+excessive socializing that leads to being fired from one's job,
+hurling an insult that causes the breakup of an important
+relationship, or using pleasure-inducing drugs that eventually
+destroy one's health.
+<br /><br />
+Impulsive behavior, even when not seriously destructive, diminishes
+a person's effectiveness in significant ways. Acting impulsively
+disallows contemplating alternative courses of action, some of which
+would have been wiser than the impulsive choice. Impulsivity also
+sidetracks people during projects that require organized sequences
+of steps or stages. Accomplishments of an impulsive person are
+therefore small, scattered, and inconsistent.
+<br /><br />
+A hallmark of intelligence, what potentially separates human beings
+from earlier life forms, is the ability to think about future
+consequences before acting on an impulse. Intelligent activity
+involves contemplation of long-range goals, organizing and planning
+routes to these goals, and persisting toward one's goals in the face
+of short-lived impulses to the contrary. The idea that intelligence
+involves impulse control is nicely captured by the term prudence, an
+alternative label for the Conscientiousness domain. Prudent means
+both wise and cautious.
+<br /><br/>
+Persons who score high on the
+Conscientiousness scale are, in fact, perceived by others as intelligent.
+The benefits of high conscientiousness are obvious. Conscientious
+individuals avoid trouble and achieve high levels of success through
+purposeful planning and persistence. They are also positively
+regarded by others as intelligent and reliable. On the negative
+side, they can be compulsive perfectionists and workaholics.
+Furthermore, extremely conscientious individuals might be regarded
+as stuffy and boring.
+<br /><br />
+Unconscientious people may be criticized for
+their unreliability, lack of ambition, and failure to stay within
+the lines, but they will experience many short-lived pleasures and
+they will never be called stuffy.`,
+  results: [
+    {
+      score: 'low', // do not translate this line
+      text: `Your score on Conscientiousness is low, indicating you like to live
+for the moment and do what feels good now. Your work tends to be
+careless and disorganized.`
+    },
+    {
+      score: 'neutral', // do not translate this line
+      text: `Your score on Conscientiousness is average. This means you are
+reasonably reliable, organized, and self-controlled.`
+    },
+    {
+      score: 'high', // do not translate this line
+      text: `Your score on Conscientiousness is high. This means you set clear
+goals and pursue them with determination. People regard you as
+reliable and hard-working.`
+    }
+  ],
+  facets: [
+    {
+      facet: 1,
+      title: 'Self-Efficacy',
+      text: `Self-Efficacy describes confidence in one's ability
+to accomplish things. High scorers believe they have the intelligence
+(common sense), drive, and self-control necessary for achieving success.
+Low scorers do not feel effective, and may have a sense that they are not
+in control of their lives.`
+    },
+    {
+      facet: 2,
+      title: 'Orderliness',
+      text: `Persons with high scores on orderliness are
+well-organized. They like to live according to routines and schedules. They
+keep lists and make plans. Low scorers tend to be disorganized and
+scattered.`
+    },
+    {
+      facet: 3,
+      title: 'Dutifulness',
+      text: `This scale reflects the strength of a person's sense
+ of duty and obligation. Those who score high on this scale have a strong
+ sense of moral obligation. Low scorers find contracts, rules, and
+ regulations overly confining. They are likely to be seen as unreliable or
+ even irresponsible.`
+    },
+    {
+      facet: 4,
+      title: 'Achievement-Striving',
+      text: `Individuals who score high on this
+scale strive hard to achieve excellence. Their drive to be recognized as
+successful keeps them on track toward their lofty goals. They often have
+a strong sense of direction in life, but extremely high scores may
+be too single-minded and obsessed with their work. Low scorers are content
+to get by with a minimal amount of work, and might be seen by others
+as lazy.`
+    },
+    {
+      facet: 5,
+      title: 'Self-Discipline',
+      text: `Self-discipline-what many people call
+will-power-refers to the ability to persist at difficult or unpleasant
+tasks until they are completed. People who possess high self-discipline
+are able to overcome reluctance to begin tasks and stay on track despite
+distractions. Those with low self-discipline procrastinate and show poor
+follow-through, often failing to complete tasks-even tasks they want very
+much to complete.`
+    },
+    {
+      facet: 6,
+      title: 'Cautiousness',
+      text: `Cautiousness describes the disposition to
+think through possibilities before acting. High scorers on the Cautiousness
+scale take their time when making decisions. Low scorers often say or do
+first thing that comes to mind without deliberating alternatives and the
+probable consequences of those alternatives.`
+    }
+  ]
+}

--- a/lib/data/id/conscientiousness.js
+++ b/lib/data/id/conscientiousness.js
@@ -1,133 +1,57 @@
 module.exports = {
   domain: 'C',
-  title: 'Conscientiousness',
-  shortDescription: 'Conscientiousness concerns the way in which we control, regulate, and direct our impulses.',
-  description: `Impulses are not inherently bad;
-occasionally time constraints require a snap decision, and acting on
-our first impulse can be an effective response. Also, in times of
-play rather than work, acting spontaneously and impulsively can be
-fun. Impulsive individuals can be seen by others as colorful,
-fun-to-be-with, and zany.
-<br /><br />
-Nonetheless, acting on impulse can lead to trouble in a number of
-ways. Some impulses are antisocial. Uncontrolled antisocial acts
-not only harm other members of society, but also can result in
-retribution toward the perpetrator of such impulsive acts. Another
-problem with impulsive acts is that they often produce immediate
-rewards but undesirable, long-term consequences. Examples include
-excessive socializing that leads to being fired from one's job,
-hurling an insult that causes the breakup of an important
-relationship, or using pleasure-inducing drugs that eventually
-destroy one's health.
-<br /><br />
-Impulsive behavior, even when not seriously destructive, diminishes
-a person's effectiveness in significant ways. Acting impulsively
-disallows contemplating alternative courses of action, some of which
-would have been wiser than the impulsive choice. Impulsivity also
-sidetracks people during projects that require organized sequences
-of steps or stages. Accomplishments of an impulsive person are
-therefore small, scattered, and inconsistent.
-<br /><br />
-A hallmark of intelligence, what potentially separates human beings
-from earlier life forms, is the ability to think about future
-consequences before acting on an impulse. Intelligent activity
-involves contemplation of long-range goals, organizing and planning
-routes to these goals, and persisting toward one's goals in the face
-of short-lived impulses to the contrary. The idea that intelligence
-involves impulse control is nicely captured by the term prudence, an
-alternative label for the Conscientiousness domain. Prudent means
-both wise and cautious.
-<br /><br/>
-Persons who score high on the
-Conscientiousness scale are, in fact, perceived by others as intelligent.
-The benefits of high conscientiousness are obvious. Conscientious
-individuals avoid trouble and achieve high levels of success through
-purposeful planning and persistence. They are also positively
-regarded by others as intelligent and reliable. On the negative
-side, they can be compulsive perfectionists and workaholics.
-Furthermore, extremely conscientious individuals might be regarded
-as stuffy and boring.
-<br /><br />
-Unconscientious people may be criticized for
-their unreliability, lack of ambition, and failure to stay within
-the lines, but they will experience many short-lived pleasures and
-they will never be called stuffy.`,
+  title: 'Kehati-hatian',
+  shortDescription: 'Kehati-hatian menyangkut cara kita mengendalikan, mengatur, dan mengarahkan impuls kita.',
+  description: `Pada dasarnya, impuls tidaklah buruk; kadang kendala waktu membutuhkan keputusan cepat, dan bertindak berdasarkan dorongan pertama kita dapat menjadi respons yang efektif. Lalu, di saat bermain daripada bekerja, bertindak secara spontan dan impulsif bisa menyenangkan. Individu yang impulsif dapat dilihat oleh orang lain sebagai orang yang penuh warna, menyenangkan, dan lucu.<br /><br />
+  Meskipun demikian, bertindak berdasarkan impuls dapat menyebabkan masalah dalam beberapa cara. Beberapa impuls bersifat antisosial. Tindakan antisosial yang tidak terkendali tidak hanya merugikan orang lain, tetapi juga dapat mengakibatkan pembalasan terhadap pelaku tindakan impulsif tersebut. Masalah lainnya dengan tindakan impulsif adalah bahwa mereka sering menghasilkan manfaat yang langsung namun dengan konsekuensi jangka panjang yang tidak diinginkan, seperti bersosialisasi secara berlebihan yang berujung pada pemecatan dari pekerjaan, melontarkan hinaan yang menyebabkan putusnya suatu hubungan penting, atau menggunakan obat-obatan yang menimbulkan kesenangan yang pada akhirnya merusak kesehatan seseorang. <br /><br />
+  Perilaku impulsif, meskipun bisa tidak merusak secara serius, dapat mengurangi keefektifan seseorang secara signifikan. Bertindak impulsif melarang merenungkan tindakan alternatif, beberapa di antaranya akan lebih bijaksana daripada pilihan impulsif. Impulsivitas juga mengalihkan orang selama proyek yang membutuhkan urutan langkah atau tahapan yang terorganisir. Prestasi orang impulsif karena itu kecil, tersebar, dan tidak konsisten.<br /><br />
+  Ciri kecerdasan, yang berpotensi memisahkan manusia dari bentuk kehidupan sebelumnya, adalah kemampuan untuk memikirkan konsekuensi masa depan sebelum bertindak berdasarkan impuls. Aktivitas yang cerdas melibatkan perenungan tujuan jangka panjang, pengorganisasian dan perencanaan rute ke tujuan ini, dan bertahan menuju tujuan seseorang dibandingkan menghadapi impuls berumur pendek. Gagasan bahwa kecerdasan melibatkan kontrol impuls ditangkap dengan baik oleh istilah kebijaksanaan, label alternatif untuk domain Kehati-hatian. Kebijaksanaan berarti bersikap bijaksana dan berhati-hati.<br /><br/>
+  Orang yang mendapat nilai tinggi pada skala Kehati-hatian, pada kenyataannya, dianggap sebagai orang yang cerdas. Manfaat dari Kehati-hatian yang tinggi sudah jelas. Individu yang teliti menghindari masalah dan mencapai tingkat keberhasilan yang tinggi melalui perencanaan dan ketekunan yang bertujuan. Mereka juga secara positif dianggap sebagai orang yang cerdas dan dapat diandalkan. Sisi negatifnya, mereka bisa menjadi perfeksionis kompulsif dan pecandu kerja. Selain itu, individu yang sangat teliti mungkin dianggap pengap dan membosankan.<br /><br />
+  Orang yang tidak hati-hati mungkin dikritik karena tidak dapat diandalkan, kurangnya ambisi, dan kegagalan untuk tetap berada di dalam garis, tetapi mereka akan mengalami banyak kesenangan berumur pendek dan mereka tidak akan pernah disebut pengap.`,
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Your score on Conscientiousness is low, indicating you like to live
-for the moment and do what feels good now. Your work tends to be
-careless and disorganized.`
+      text: `Nilai Anda pada Kehati-hatian rendah, yang menunjukkan Anda suka hidup untuk saat ini dan melakukan apa yang terasa baik sekarang. Pekerjaan Anda cenderung ceroboh dan tidak teratur.`
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Your score on Conscientiousness is average. This means you are
-reasonably reliable, organized, and self-controlled.`
+      text: `Nilai Anda pada Kehati-hatian adalah rata-rata. Ini berarti Anda cukup dapat diandalkan, terorganisir, dan dapat mengendalikan diri.`
     },
     {
       score: 'high', // do not translate this line
-      text: `Your score on Conscientiousness is high. This means you set clear
-goals and pursue them with determination. People regard you as
-reliable and hard-working.`
+      text: `Nilai Anda pada Kehati-hatian tinggi. Ini berarti Anda menetapkan tujuan yang jelas dan mengejarnya dengan tekad. Orang-orang menganggap Anda sebagai orang yang dapat diandalkan dan pekerja keras.`
     }
   ],
   facets: [
     {
       facet: 1,
-      title: 'Self-Efficacy',
-      text: `Self-Efficacy describes confidence in one's ability
-to accomplish things. High scorers believe they have the intelligence
-(common sense), drive, and self-control necessary for achieving success.
-Low scorers do not feel effective, and may have a sense that they are not
-in control of their lives.`
+      title: 'Efikasi Diri',
+      text: `Efikasi Diri menggambarkan kepercayaan diri pada kemampuan seseorang untuk mencapai sesuatu. Orang-orang yang mendapatkan nilai tinggi percaya bahwa mereka memiliki kecerdasan (akal sehat), dorongan, dan pengendalian diri yang diperlukan untuk mencapai kesuksesan. Orang-orang yang mendapatkan nilai rendah tidak merasa efektif, dan mungkin merasa bahwa mereka tidak mengendalikan hidup mereka.`
     },
     {
       facet: 2,
-      title: 'Orderliness',
-      text: `Persons with high scores on orderliness are
-well-organized. They like to live according to routines and schedules. They
-keep lists and make plans. Low scorers tend to be disorganized and
-scattered.`
+      title: 'Keteraturan',
+      text: `Orang-orang dengan nilai tinggi pada Keteraturan terorganisir dengan baik. Mereka suka hidup sesuai dengan rutinitas dan jadwal. Mereka menyimpan daftar dan membuat rencana. Orang-orang yang mendapatkan nilai rendah cenderung tidak terorganisir dan tersebar.`
     },
     {
       facet: 3,
-      title: 'Dutifulness',
-      text: `This scale reflects the strength of a person's sense
- of duty and obligation. Those who score high on this scale have a strong
- sense of moral obligation. Low scorers find contracts, rules, and
- regulations overly confining. They are likely to be seen as unreliable or
- even irresponsible.`
+      title: 'Ketaatan',
+      text: `Skala ini mencerminkan kekuatan rasa kewajiban seseorang. Mereka yang mendapat nilai tinggi pada skala ini memiliki rasa kewajiban moral yang kuat. Orang-orang yang mendapatkan nilai rendah merasa kontrak, aturan, dan peraturan terlalu membatasi. Mereka cenderung dianggap tidak dapat diandalkan atau bahkan tidak bertanggung jawab.`
     },
     {
       facet: 4,
-      title: 'Achievement-Striving',
-      text: `Individuals who score high on this
-scale strive hard to achieve excellence. Their drive to be recognized as
-successful keeps them on track toward their lofty goals. They often have
-a strong sense of direction in life, but extremely high scores may
-be too single-minded and obsessed with their work. Low scorers are content
-to get by with a minimal amount of work, and might be seen by others
-as lazy.`
+      title: 'Perjuangan akan Prestasi',
+      text: `Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi skor yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapatkan nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.`
     },
     {
       facet: 5,
-      title: 'Self-Discipline',
-      text: `Self-discipline-what many people call
-will-power-refers to the ability to persist at difficult or unpleasant
-tasks until they are completed. People who possess high self-discipline
-are able to overcome reluctance to begin tasks and stay on track despite
-distractions. Those with low self-discipline procrastinate and show poor
-follow-through, often failing to complete tasks-even tasks they want very
-much to complete.`
+      title: 'Disiplin Diri',
+      text: `Disiplin Diri, yang oleh banyak orang disebut kemauan, mengacu pada kemampuan untuk bertahan pada tugas-tugas yang sulit atau tidak menyenangkan sampai tugas itu selesai. Orang yang memiliki disiplin diri yang tinggi mampu mengatasi keengganan untuk memulai tugas dan tetap pada jalurnya meskipun ada gangguan. Mereka dengan disiplin diri yang rendah menunda-nunda dan menunjukkan tindak lanjut yang buruk, sering gagal menyelesaikan tugas-bahkan tugas yang sangat ingin mereka selesaikan.`
     },
     {
       facet: 6,
-      title: 'Cautiousness',
-      text: `Cautiousness describes the disposition to
-think through possibilities before acting. High scorers on the Cautiousness
-scale take their time when making decisions. Low scorers often say or do
-first thing that comes to mind without deliberating alternatives and the
-probable consequences of those alternatives.`
+      title: 'Keawasan',
+      text: `Keawasan menggambarkan disposisi untuk memikirkan kemungkinan sebelum bertindak. Orang-orang yang mendapatkan nilai tinggi pada skala Kewaspadaan meluangkan waktu mereka saat membuat keputusan. Orang-orang yang mendapatkan nilai rendah sering mengatakan atau melakukan hal pertama yang terlintas dalam pikiran tanpa mempertimbangkan alternatif dan kemungkinan konsekuensi dari alternatif tersebut.`
     }
   ]
 }

--- a/lib/data/id/conscientiousness.js
+++ b/lib/data/id/conscientiousness.js
@@ -26,22 +26,22 @@ module.exports = {
     {
       facet: 1,
       title: 'Efikasi Diri',
-      text: `Efikasi Diri menggambarkan kepercayaan diri pada kemampuan seseorang untuk mencapai sesuatu. Orang-orang yang mendapatkan nilai tinggi percaya bahwa mereka memiliki kecerdasan (akal sehat), dorongan, dan pengendalian diri yang diperlukan untuk mencapai kesuksesan. Orang-orang yang mendapatkan nilai rendah tidak merasa efektif, dan mungkin merasa bahwa mereka tidak mengendalikan hidup mereka.`
+      text: `Efikasi Diri menggambarkan kepercayaan diri pada kemampuan seseorang untuk mencapai sesuatu. Orang-orang yang mendapat nilai tinggi percaya bahwa mereka memiliki kecerdasan (akal sehat), dorongan, dan pengendalian diri yang diperlukan untuk mencapai kesuksesan. Orang-orang yang mendapat nilai rendah tidak merasa efektif, dan mungkin merasa bahwa mereka tidak mengendalikan hidup mereka.`
     },
     {
       facet: 2,
       title: 'Keteraturan',
-      text: `Orang-orang dengan nilai tinggi pada Keteraturan terorganisir dengan baik. Mereka suka hidup sesuai dengan rutinitas dan jadwal. Mereka menyimpan daftar dan membuat rencana. Orang-orang yang mendapatkan nilai rendah cenderung tidak terorganisir dan tersebar.`
+      text: `Orang-orang dengan nilai tinggi pada Keteraturan terorganisir dengan baik. Mereka suka hidup sesuai dengan rutinitas dan jadwal. Mereka menyimpan daftar dan membuat rencana. Orang-orang yang mendapat nilai rendah cenderung tidak terorganisir dan tersebar.`
     },
     {
       facet: 3,
       title: 'Ketaatan',
-      text: `Skala ini mencerminkan kekuatan rasa kewajiban seseorang. Mereka yang mendapat nilai tinggi pada skala ini memiliki rasa kewajiban moral yang kuat. Orang-orang yang mendapatkan nilai rendah merasa kontrak, aturan, dan peraturan terlalu membatasi. Mereka cenderung dianggap tidak dapat diandalkan atau bahkan tidak bertanggung jawab.`
+      text: `Skala ini mencerminkan kekuatan rasa kewajiban seseorang. Mereka yang mendapat nilai tinggi pada skala ini memiliki rasa kewajiban moral yang kuat. Orang-orang yang mendapat nilai rendah merasa kontrak, aturan, dan peraturan terlalu membatasi. Mereka cenderung dianggap tidak dapat diandalkan atau bahkan tidak bertanggung jawab.`
     },
     {
       facet: 4,
       title: 'Perjuangan akan Prestasi',
-      text: `Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi skor yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapatkan nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.`
+      text: `Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi skor yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapat nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.`
     },
     {
       facet: 5,
@@ -51,7 +51,7 @@ module.exports = {
     {
       facet: 6,
       title: 'Keawasan',
-      text: `Keawasan menggambarkan disposisi untuk memikirkan kemungkinan sebelum bertindak. Orang-orang yang mendapatkan nilai tinggi pada skala Kewaspadaan meluangkan waktu mereka saat membuat keputusan. Orang-orang yang mendapatkan nilai rendah sering mengatakan atau melakukan hal pertama yang terlintas dalam pikiran tanpa mempertimbangkan alternatif dan kemungkinan konsekuensi dari alternatif tersebut.`
+      text: `Keawasan menggambarkan disposisi untuk memikirkan kemungkinan sebelum bertindak. Orang-orang yang mendapat nilai tinggi pada skala Kewaspadaan meluangkan waktu mereka saat membuat keputusan. Orang-orang yang mendapat nilai rendah sering mengatakan atau melakukan hal pertama yang terlintas dalam pikiran tanpa mempertimbangkan alternatif dan kemungkinan konsekuensi dari alternatif tersebut.`
     }
   ]
 }

--- a/lib/data/id/conscientiousness.js
+++ b/lib/data/id/conscientiousness.js
@@ -11,47 +11,47 @@ module.exports = {
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Nilai Anda pada Kehati-hatian rendah, yang menunjukkan Anda suka hidup untuk saat ini dan melakukan apa yang terasa baik sekarang. Pekerjaan Anda cenderung ceroboh dan tidak teratur.`
+      text: 'Nilai Anda pada Kehati-hatian rendah, yang menunjukkan Anda suka hidup untuk saat ini dan melakukan apa yang terasa baik sekarang. Pekerjaan Anda cenderung ceroboh dan tidak teratur.'
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Nilai Anda pada Kehati-hatian adalah rata-rata. Ini berarti Anda cukup dapat diandalkan, terorganisir, dan dapat mengendalikan diri.`
+      text: 'Nilai Anda pada Kehati-hatian adalah rata-rata. Ini berarti Anda cukup dapat diandalkan, terorganisir, dan dapat mengendalikan diri.'
     },
     {
       score: 'high', // do not translate this line
-      text: `Nilai Anda pada Kehati-hatian tinggi. Ini berarti Anda menetapkan tujuan yang jelas dan mengejarnya dengan tekad. Orang-orang menganggap Anda sebagai orang yang dapat diandalkan dan pekerja keras.`
+      text: 'Nilai Anda pada Kehati-hatian tinggi. Ini berarti Anda menetapkan tujuan yang jelas dan mengejarnya dengan tekad. Orang-orang menganggap Anda sebagai orang yang dapat diandalkan dan pekerja keras.'
     }
   ],
   facets: [
     {
       facet: 1,
       title: 'Efikasi Diri',
-      text: `Efikasi Diri menggambarkan kepercayaan diri pada kemampuan seseorang untuk mencapai sesuatu. Orang-orang yang mendapat nilai tinggi percaya bahwa mereka memiliki kecerdasan (akal sehat), dorongan, dan pengendalian diri yang diperlukan untuk mencapai kesuksesan. Orang-orang yang mendapat nilai rendah tidak merasa efektif, dan mungkin merasa bahwa mereka tidak mengendalikan hidup mereka.`
+      text: 'Efikasi Diri menggambarkan kepercayaan diri pada kemampuan seseorang untuk mencapai sesuatu. Orang-orang yang mendapat nilai tinggi percaya bahwa mereka memiliki kecerdasan (akal sehat), dorongan, dan pengendalian diri yang diperlukan untuk mencapai kesuksesan. Orang-orang yang mendapat nilai rendah tidak merasa efektif, dan mungkin merasa bahwa mereka tidak mengendalikan hidup mereka.'
     },
     {
       facet: 2,
       title: 'Keteraturan',
-      text: `Orang-orang dengan nilai tinggi pada Keteraturan terorganisir dengan baik. Mereka suka hidup sesuai dengan rutinitas dan jadwal. Mereka menyimpan daftar dan membuat rencana. Orang-orang yang mendapat nilai rendah cenderung tidak terorganisir dan tersebar.`
+      text: 'Orang-orang dengan nilai tinggi pada Keteraturan terorganisir dengan baik. Mereka suka hidup sesuai dengan rutinitas dan jadwal. Mereka menyimpan daftar dan membuat rencana. Orang-orang yang mendapat nilai rendah cenderung tidak terorganisir dan tersebar.'
     },
     {
       facet: 3,
       title: 'Ketaatan',
-      text: `Skala ini mencerminkan kekuatan rasa kewajiban seseorang. Mereka yang mendapat nilai tinggi pada skala ini memiliki rasa kewajiban moral yang kuat. Orang-orang yang mendapat nilai rendah merasa kontrak, aturan, dan peraturan terlalu membatasi. Mereka cenderung dianggap tidak dapat diandalkan atau bahkan tidak bertanggung jawab.`
+      text: 'Skala ini mencerminkan kekuatan rasa kewajiban seseorang. Mereka yang mendapat nilai tinggi pada skala ini memiliki rasa kewajiban moral yang kuat. Orang-orang yang mendapat nilai rendah merasa kontrak, aturan, dan peraturan terlalu membatasi. Mereka cenderung dianggap tidak dapat diandalkan atau bahkan tidak bertanggung jawab.'
     },
     {
       facet: 4,
       title: 'Perjuangan akan Prestasi',
-      text: `Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi nilai yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapat nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.`
+      text: 'Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi nilai yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapat nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.'
     },
     {
       facet: 5,
       title: 'Disiplin Diri',
-      text: `Disiplin Diri, yang oleh banyak orang disebut kemauan, mengacu pada kemampuan untuk bertahan pada tugas-tugas yang sulit atau tidak menyenangkan sampai tugas itu selesai. Orang yang memiliki disiplin diri yang tinggi mampu mengatasi keengganan untuk memulai tugas dan tetap pada jalurnya meskipun ada gangguan. Mereka dengan disiplin diri yang rendah menunda-nunda dan menunjukkan tindak lanjut yang buruk, sering gagal menyelesaikan tugas-bahkan tugas yang sangat ingin mereka selesaikan.`
+      text: 'Disiplin Diri, yang oleh banyak orang disebut kemauan, mengacu pada kemampuan untuk bertahan pada tugas-tugas yang sulit atau tidak menyenangkan sampai tugas itu selesai. Orang yang memiliki disiplin diri yang tinggi mampu mengatasi keengganan untuk memulai tugas dan tetap pada jalurnya meskipun ada gangguan. Mereka dengan disiplin diri yang rendah menunda-nunda dan menunjukkan tindak lanjut yang buruk, sering gagal menyelesaikan tugas-bahkan tugas yang sangat ingin mereka selesaikan.'
     },
     {
       facet: 6,
       title: 'Keawasan',
-      text: `Keawasan menggambarkan disposisi untuk memikirkan kemungkinan sebelum bertindak. Orang-orang yang mendapat nilai tinggi pada skala Kewaspadaan meluangkan waktu mereka saat membuat keputusan. Orang-orang yang mendapat nilai rendah sering mengatakan atau melakukan hal pertama yang terlintas dalam pikiran tanpa mempertimbangkan alternatif dan kemungkinan konsekuensi dari alternatif tersebut.`
+      text: 'Keawasan menggambarkan disposisi untuk memikirkan kemungkinan sebelum bertindak. Orang-orang yang mendapat nilai tinggi pada skala Kewaspadaan meluangkan waktu mereka saat membuat keputusan. Orang-orang yang mendapat nilai rendah sering mengatakan atau melakukan hal pertama yang terlintas dalam pikiran tanpa mempertimbangkan alternatif dan kemungkinan konsekuensi dari alternatif tersebut.'
     }
   ]
 }

--- a/lib/data/id/conscientiousness.js
+++ b/lib/data/id/conscientiousness.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       facet: 4,
       title: 'Perjuangan akan Prestasi',
-      text: `Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi skor yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapat nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.`
+      text: `Individu yang mendapat nilai tinggi pada skala ini berusaha keras untuk mencapai keunggulan. Dorongan mereka untuk diakui sebagai sukses membuat mereka tetap di jalur menuju tujuan mulia mereka. Mereka sering memiliki rasa arah yang kuat dalam hidup, tetapi nilai yang sangat tinggi mungkin terlalu berpikiran tunggal dan terobsesi dengan pekerjaan mereka.  Orang-orang yang mendapat nilai rendah puas dengan pekerjaan minimal, dan mungkin dilihat oleh orang lain sebagai malas.`
     },
     {
       facet: 5,

--- a/lib/data/id/extraversion.js
+++ b/lib/data/id/extraversion.js
@@ -1,0 +1,98 @@
+module.exports = {
+  domain: 'E',
+  title: 'Extraversion',
+  shortDescription: 'Extraversion is marked by pronounced engagement with the external world.',
+  description: `Extraverts enjoy being with people, are full of energy, and
+often experience positive emotions. They tend to be enthusiastic,
+action-oriented, individuals who are likely to say "Yes!" or "Let's
+go!" to opportunities for excitement. In groups they like to talk,
+assert themselves, and draw attention to themselves.
+<br /><br />
+Introverts lack the exuberance, energy, and activity levels of
+extraverts. They tend to be quiet, low-key, deliberate, and
+disengaged from the social world. Their lack of social involvement
+should not be interpreted as shyness or depression; the
+introvert simply needs less stimulation than an extravert and prefers
+to be alone. <br /><br />The independence and reserve of the introvert is
+sometimes mistaken as unfriendliness or arrogance. In reality, an
+introvert who scores high on the agreeableness dimension will not
+seek others out but will be quite pleasant when approached.`,
+  results: [
+    {
+      score: 'low', // do not translate this line
+      text: `Your score on Extraversion is low, indicating you are
+introverted, reserved, and quiet. You enjoy solitude and solitary
+activities. Your socialization tends to be restricted to a few close friends.`
+    },
+    {
+      score: 'neutral', // do not translate this line
+      text: `Your score on Extraversion is average, indicating you are
+neither a subdued loner nor a jovial chatterbox. You enjoy time with
+others but also time alone.`
+    },
+    {
+      score: 'high', // do not translate this line
+      text: `Your score on Extraversion is high, indicating you are
+sociable, outgoing, energetic, and lively. You prefer to be around
+people much of the time.`
+    }
+  ],
+  facets: [
+    {
+      facet: 1,
+      title: 'Friendliness',
+      text: `Friendly people genuinely like other people
+and openly demonstrate positive feelings toward others. They make
+friends quickly and it is easy for them to form close, intimate
+relationships. Low scorers on Friendliness are not necessarily cold
+and hostile, but they do not reach out to others and are perceived
+as distant and reserved.`
+    },
+    {
+      facet: 2,
+      title: 'Gregariousness',
+      text: `Gregarious people find the company of
+others pleasantly stimulating and rewarding. They enjoy the
+excitement of crowds. Low scorers tend to feel overwhelmed by, and
+therefore actively avoid, large crowds. They do not necessarily
+dislike being with people sometimes, but their need for privacy and
+time to themselves is much greater than for individuals who score
+high on this scale.`
+    },
+    {
+      facet: 3,
+      title: 'Assertiveness',
+      text: `High scorers Assertiveness like to speak
+ out, take charge, and direct the activities of others. They tend to
+ be leaders in groups. Low scorers tend not to talk much and let
+ others control the activities of groups.`
+    },
+    {
+      facet: 4,
+      title: 'Activity Level',
+      text: `Active individuals lead fast-paced, busy
+ lives. They move about quickly, energetically, and vigorously, and
+ they are involved in many activities. People who score low on this
+ scale follow a slower and more leisurely, relaxed pace.`
+    },
+    {
+      facet: 5,
+      title: 'Excitement-Seeking',
+      text: `High scorers on this scale are easily
+bored without high levels of stimulation. They love bright lights
+and hustle and bustle. They are likely to take risks and seek
+thrills. Low scorers are overwhelmed by noise and commotion and are
+adverse to thrill-seeking.`
+    },
+    {
+      facet: 6,
+      title: 'Cheerfulness',
+      text: `This scale measures positive mood and
+feelings, not negative emotions (which are a part of the
+Neuroticism domain). Persons who score high on this scale typically
+experience a range of positive feelings, including happiness,
+enthusiasm, optimism, and joy. Low scorers are not as prone to such
+energetic, high spirits.`
+    }
+  ]
+}

--- a/lib/data/id/extraversion.js
+++ b/lib/data/id/extraversion.js
@@ -8,47 +8,47 @@ module.exports = {
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Nilai Anda pada Kehati-hatian rendah, yang menunjukkan Anda adalh seorang yang introvert dan pendiam. Anda menikmati kesendirian dan aktivitas menyendiri. Sosialisasi Anda cenderung terbatas pada beberapa teman dekat.`
+      text: 'Nilai Anda pada Kehati-hatian rendah, yang menunjukkan Anda adalh seorang yang introvert dan pendiam. Anda menikmati kesendirian dan aktivitas menyendiri. Sosialisasi Anda cenderung terbatas pada beberapa teman dekat.'
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Nilai Anda pada Kehati-hatian adalah rata-rata, yang menunjukkan bahwa Anda bukanlah seorang penyendiri yang pendiam atau orang yang suka mengobrol. Anda menikmati waktu bersama orang lain tetapi juga waktu sendirian.`
+      text: 'Nilai Anda pada Kehati-hatian adalah rata-rata, yang menunjukkan bahwa Anda bukanlah seorang penyendiri yang pendiam atau orang yang suka mengobrol. Anda menikmati waktu bersama orang lain tetapi juga waktu sendirian.'
     },
     {
       score: 'high', // do not translate this line
-      text: `Nilai Anda pada Kehati-hatian tinggi, yang menunjukkan Anda mudah bergaul, ramah, energik, dan lincah. Kamu lebih suka berada di sekitar orang-orang sepanjang waktu.`
+      text: 'Nilai Anda pada Kehati-hatian tinggi, yang menunjukkan Anda mudah bergaul, ramah, energik, dan lincah. Kamu lebih suka berada di sekitar orang-orang sepanjang waktu.'
     }
   ],
   facets: [
     {
       facet: 1,
       title: 'Keramahan',
-      text: `Orang yang ramah benar-benar menyukai orang lain dan secara terbuka menunjukkan perasaan positif terhadap orang lain. Mereka berteman dengan cepat dan mudah bagi mereka untuk membentuk hubungan yang dekat dan intim. Orang-orang yang mendapat nilai rendah pada Keramahan tidak selalu dingin dan bermusuhan, tetapi mereka tidak menjangkau orang lain dan dianggap jauh dan pendiam.`
+      text: 'Orang yang ramah benar-benar menyukai orang lain dan secara terbuka menunjukkan perasaan positif terhadap orang lain. Mereka berteman dengan cepat dan mudah bagi mereka untuk membentuk hubungan yang dekat dan intim. Orang-orang yang mendapat nilai rendah pada Keramahan tidak selalu dingin dan bermusuhan, tetapi mereka tidak menjangkau orang lain dan dianggap jauh dan pendiam.'
     },
     {
       facet: 2,
       title: 'Kebersamaan',
-      text: `Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapat nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat nilai tinggi pada skala ini.`
+      text: 'Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapat nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat nilai tinggi pada skala ini.'
     },
     {
       facet: 3,
       title: 'Ketegasan',
-      text: `Orang-orang yang mendapat nilai Ketegasan yang tinggi suka berbicara, bertanggung jawab, dan mengarahkan aktivitas orang lain. Mereka cenderung menjadi pemimpin dalam kelompok. Orang-orang yang mendapat nilai rendah cenderung tidak banyak bicara dan membiarkan orang lain mengontrol aktivitas kelompok.`
+      text: 'Orang-orang yang mendapat nilai Ketegasan yang tinggi suka berbicara, bertanggung jawab, dan mengarahkan aktivitas orang lain. Mereka cenderung menjadi pemimpin dalam kelompok. Orang-orang yang mendapat nilai rendah cenderung tidak banyak bicara dan membiarkan orang lain mengontrol aktivitas kelompok.'
     },
     {
       facet: 4,
       title: 'Tingkat Aktivitas',
-      text: `Individu yang aktif menjalani kehidupan yang serba cepat dan sibuk. Mereka bergerak cepat, penuh semangat, dan penuh semangat, dan mereka terlibat dalam banyak kegiatan. Orang-orang yang mendapat nilai rendah pada skala ini mengikuti langkah yang lebih lambat dan lebih santai.`
+      text: 'Individu yang aktif menjalani kehidupan yang serba cepat dan sibuk. Mereka bergerak cepat, penuh semangat, dan penuh semangat, dan mereka terlibat dalam banyak kegiatan. Orang-orang yang mendapat nilai rendah pada skala ini mengikuti langkah yang lebih lambat dan lebih santai.'
     },
     {
       facet: 5,
       title: 'Pencarian Kegembiraan',
-      text: `Pencetak nilai tinggi pada skala ini mudah bosan tanpa stimulasi tingkat tinggi. Mereka menyukai lampu terang dan hiruk pikuk. Mereka cenderung mengambil risiko dan mencari sensasi. Pencetak nilai rendah kewalahan oleh kebisingan dan keributan dan tidak cocok dengan pencarian sensasi.`
+      text: 'Pencetak nilai tinggi pada skala ini mudah bosan tanpa stimulasi tingkat tinggi. Mereka menyukai lampu terang dan hiruk pikuk. Mereka cenderung mengambil risiko dan mencari sensasi. Pencetak nilai rendah kewalahan oleh kebisingan dan keributan dan tidak cocok dengan pencarian sensasi.'
     },
     {
       facet: 6,
       title: 'Kebahagiaan',
-      text: `Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat nilai tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapat nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.`
+      text: 'Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat nilai tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapat nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.'
     }
   ]
 }

--- a/lib/data/id/extraversion.js
+++ b/lib/data/id/extraversion.js
@@ -28,7 +28,7 @@ module.exports = {
     {
       facet: 2,
       title: 'Kebersamaan',
-      text: `Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapat nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat skor tinggi pada skala ini.`
+      text: `Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapat nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat nilai tinggi pada skala ini.`
     },
     {
       facet: 3,
@@ -43,12 +43,12 @@ module.exports = {
     {
       facet: 5,
       title: 'Pencarian Kegembiraan',
-      text: `Pencetak skor tinggi pada skala ini mudah bosan tanpa stimulasi tingkat tinggi. Mereka menyukai lampu terang dan hiruk pikuk. Mereka cenderung mengambil risiko dan mencari sensasi. Pencetak skor rendah kewalahan oleh kebisingan dan keributan dan tidak cocok dengan pencarian sensasi.`
+      text: `Pencetak nilai tinggi pada skala ini mudah bosan tanpa stimulasi tingkat tinggi. Mereka menyukai lampu terang dan hiruk pikuk. Mereka cenderung mengambil risiko dan mencari sensasi. Pencetak nilai rendah kewalahan oleh kebisingan dan keributan dan tidak cocok dengan pencarian sensasi.`
     },
     {
       facet: 6,
       title: 'Kebahagiaan',
-      text: `Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat skor tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapat nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.`
+      text: `Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat nilai tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapat nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.`
     }
   ]
 }

--- a/lib/data/id/extraversion.js
+++ b/lib/data/id/extraversion.js
@@ -1,98 +1,54 @@
 module.exports = {
   domain: 'E',
-  title: 'Extraversion',
-  shortDescription: 'Extraversion is marked by pronounced engagement with the external world.',
-  description: `Extraverts enjoy being with people, are full of energy, and
-often experience positive emotions. They tend to be enthusiastic,
-action-oriented, individuals who are likely to say "Yes!" or "Let's
-go!" to opportunities for excitement. In groups they like to talk,
-assert themselves, and draw attention to themselves.
-<br /><br />
-Introverts lack the exuberance, energy, and activity levels of
-extraverts. They tend to be quiet, low-key, deliberate, and
-disengaged from the social world. Their lack of social involvement
-should not be interpreted as shyness or depression; the
-introvert simply needs less stimulation than an extravert and prefers
-to be alone. <br /><br />The independence and reserve of the introvert is
-sometimes mistaken as unfriendliness or arrogance. In reality, an
-introvert who scores high on the agreeableness dimension will not
-seek others out but will be quite pleasant when approached.`,
+  title: 'Ekstraversi',
+  shortDescription: 'Ekstraversi ditandai dengan keterlibatan yang nyata dengan dunia luar .',
+  description: `Para ekstrovert menikmati kebersamaan dengan orang-orang, penuh energi, dan sering mengalami emosi positif. Mereka cenderung antusias, berorientasi pada tindakan, individu yang cenderung mengatakan "Ya!" atau "Ayo!" untuk mendapatkan kesempatan kegembiraan. Dalam kelompok mereka suka berbicara, menegaskan diri mereka sendiri, dan menarik perhatian pada diri mereka sendiri.<br /><br />
+  Para introvert tidak memiliki tingkat kegembiraan, energi, dan aktivitas seperti para ekstrovert. Mereka cenderung pendiam, rendah hati, berhati-hati, dan melepaskan diri dari dunia sosial. Kurangnya keterlibatan sosial mereka tidak boleh ditafsirkan sebagai rasa malu atau depresi; introvert hanya membutuhkan lebih sedikit stimulasi daripada ekstrovert dan lebih suka menyendiri.<br /><br />
+  Kemandirian dan sikap tertutup dari seorang introvert terkadang disalahartikan sebagai tidak ramah atau arogan. Pada kenyataannya, seorang introvert yang mendapat nilai tinggi pada dimensi Kepersetujuan tidak akan mencari orang lain tetapi akan sangat menyenangkan ketika didekati.`,
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Your score on Extraversion is low, indicating you are
-introverted, reserved, and quiet. You enjoy solitude and solitary
-activities. Your socialization tends to be restricted to a few close friends.`
+      text: `Nilai Anda pada Kehati-hatian rendah, yang menunjukkan Anda adalh seorang yang introvert dan pendiam. Anda menikmati kesendirian dan aktivitas menyendiri. Sosialisasi Anda cenderung terbatas pada beberapa teman dekat.`
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Your score on Extraversion is average, indicating you are
-neither a subdued loner nor a jovial chatterbox. You enjoy time with
-others but also time alone.`
+      text: `Nilai Anda pada Kehati-hatian adalah rata-rata, yang menunjukkan bahwa Anda bukanlah seorang penyendiri yang pendiam atau orang yang suka mengobrol. Anda menikmati waktu bersama orang lain tetapi juga waktu sendirian.`
     },
     {
       score: 'high', // do not translate this line
-      text: `Your score on Extraversion is high, indicating you are
-sociable, outgoing, energetic, and lively. You prefer to be around
-people much of the time.`
+      text: `Nilai Anda pada Kehati-hatian tinggi, yang menunjukkan Anda mudah bergaul, ramah, energik, dan lincah. Kamu lebih suka berada di sekitar orang-orang sepanjang waktu.`
     }
   ],
   facets: [
     {
       facet: 1,
-      title: 'Friendliness',
-      text: `Friendly people genuinely like other people
-and openly demonstrate positive feelings toward others. They make
-friends quickly and it is easy for them to form close, intimate
-relationships. Low scorers on Friendliness are not necessarily cold
-and hostile, but they do not reach out to others and are perceived
-as distant and reserved.`
+      title: 'Keramahan',
+      text: `Orang yang ramah benar-benar menyukai orang lain dan secara terbuka menunjukkan perasaan positif terhadap orang lain. Mereka berteman dengan cepat dan mudah bagi mereka untuk membentuk hubungan yang dekat dan intim. Orang-orang yang mendapatkan nilai rendah pada Keramahan tidak selalu dingin dan bermusuhan, tetapi mereka tidak menjangkau orang lain dan dianggap jauh dan pendiam.`
     },
     {
       facet: 2,
-      title: 'Gregariousness',
-      text: `Gregarious people find the company of
-others pleasantly stimulating and rewarding. They enjoy the
-excitement of crowds. Low scorers tend to feel overwhelmed by, and
-therefore actively avoid, large crowds. They do not necessarily
-dislike being with people sometimes, but their need for privacy and
-time to themselves is much greater than for individuals who score
-high on this scale.`
+      title: 'Kebersamaan',
+      text: `Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapatkan nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat skor tinggi pada skala ini.`
     },
     {
       facet: 3,
-      title: 'Assertiveness',
-      text: `High scorers Assertiveness like to speak
- out, take charge, and direct the activities of others. They tend to
- be leaders in groups. Low scorers tend not to talk much and let
- others control the activities of groups.`
+      title: 'Ketegasan',
+      text: `Orang-orang yang mendapatkan nilai Ketegasan yang tinggi suka berbicara, bertanggung jawab, dan mengarahkan aktivitas orang lain. Mereka cenderung menjadi pemimpin dalam kelompok. Orang-orang yang mendapatkan nilai rendah cenderung tidak banyak bicara dan membiarkan orang lain mengontrol aktivitas kelompok.`
     },
     {
       facet: 4,
-      title: 'Activity Level',
-      text: `Active individuals lead fast-paced, busy
- lives. They move about quickly, energetically, and vigorously, and
- they are involved in many activities. People who score low on this
- scale follow a slower and more leisurely, relaxed pace.`
+      title: 'Tingkat Aktivitas',
+      text: `Individu yang aktif menjalani kehidupan yang serba cepat dan sibuk. Mereka bergerak cepat, penuh semangat, dan penuh semangat, dan mereka terlibat dalam banyak kegiatan. Orang-orang yang mendapat nilai rendah pada skala ini mengikuti langkah yang lebih lambat dan lebih santai.`
     },
     {
       facet: 5,
-      title: 'Excitement-Seeking',
-      text: `High scorers on this scale are easily
-bored without high levels of stimulation. They love bright lights
-and hustle and bustle. They are likely to take risks and seek
-thrills. Low scorers are overwhelmed by noise and commotion and are
-adverse to thrill-seeking.`
+      title: 'Pencarian Kegembiraan',
+      text: `Pencetak skor tinggi pada skala ini mudah bosan tanpa stimulasi tingkat tinggi. Mereka menyukai lampu terang dan hiruk pikuk. Mereka cenderung mengambil risiko dan mencari sensasi. Pencetak skor rendah kewalahan oleh kebisingan dan keributan dan tidak cocok dengan pencarian sensasi.`
     },
     {
       facet: 6,
-      title: 'Cheerfulness',
-      text: `This scale measures positive mood and
-feelings, not negative emotions (which are a part of the
-Neuroticism domain). Persons who score high on this scale typically
-experience a range of positive feelings, including happiness,
-enthusiasm, optimism, and joy. Low scorers are not as prone to such
-energetic, high spirits.`
+      title: 'Kebahagiaan',
+      text: `Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat skor tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapatkan nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.`
     }
   ]
 }

--- a/lib/data/id/extraversion.js
+++ b/lib/data/id/extraversion.js
@@ -23,17 +23,17 @@ module.exports = {
     {
       facet: 1,
       title: 'Keramahan',
-      text: `Orang yang ramah benar-benar menyukai orang lain dan secara terbuka menunjukkan perasaan positif terhadap orang lain. Mereka berteman dengan cepat dan mudah bagi mereka untuk membentuk hubungan yang dekat dan intim. Orang-orang yang mendapatkan nilai rendah pada Keramahan tidak selalu dingin dan bermusuhan, tetapi mereka tidak menjangkau orang lain dan dianggap jauh dan pendiam.`
+      text: `Orang yang ramah benar-benar menyukai orang lain dan secara terbuka menunjukkan perasaan positif terhadap orang lain. Mereka berteman dengan cepat dan mudah bagi mereka untuk membentuk hubungan yang dekat dan intim. Orang-orang yang mendapat nilai rendah pada Keramahan tidak selalu dingin dan bermusuhan, tetapi mereka tidak menjangkau orang lain dan dianggap jauh dan pendiam.`
     },
     {
       facet: 2,
       title: 'Kebersamaan',
-      text: `Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapatkan nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat skor tinggi pada skala ini.`
+      text: `Orang-orang yang suka bersama merasa bahwa kebersamaan dengan orang lain sangat menyenangkan dan bermanfaat. Mereka menikmati kegembiraan orang banyak. Orang-orang yang mendapat nilai rendah cenderung merasa kewalahan oleh, dan karena itu secara aktif menghindari, kerumunan besar. Mereka tidak selalu tidak suka bersama orang kadang-kadang, tetapi kebutuhan mereka akan privasi dan waktu untuk diri mereka sendiri jauh lebih besar daripada individu yang mendapat skor tinggi pada skala ini.`
     },
     {
       facet: 3,
       title: 'Ketegasan',
-      text: `Orang-orang yang mendapatkan nilai Ketegasan yang tinggi suka berbicara, bertanggung jawab, dan mengarahkan aktivitas orang lain. Mereka cenderung menjadi pemimpin dalam kelompok. Orang-orang yang mendapatkan nilai rendah cenderung tidak banyak bicara dan membiarkan orang lain mengontrol aktivitas kelompok.`
+      text: `Orang-orang yang mendapat nilai Ketegasan yang tinggi suka berbicara, bertanggung jawab, dan mengarahkan aktivitas orang lain. Mereka cenderung menjadi pemimpin dalam kelompok. Orang-orang yang mendapat nilai rendah cenderung tidak banyak bicara dan membiarkan orang lain mengontrol aktivitas kelompok.`
     },
     {
       facet: 4,
@@ -48,7 +48,7 @@ module.exports = {
     {
       facet: 6,
       title: 'Kebahagiaan',
-      text: `Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat skor tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapatkan nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.`
+      text: `Skala ini mengukur suasana hati dan perasaan positif, bukan emosi negatif (yang merupakan bagian dari domain Neurotikisme). Orang yang mendapat skor tinggi pada skala ini biasanya mengalami berbagai perasaan positif, termasuk kebahagiaan, antusiasme, optimisme, dan kegembiraan. Orang-orang yang mendapat nilai rendah tidak rentan terhadap semangat tinggi dan energik seperti itu.`
     }
   ]
 }

--- a/lib/data/id/index.js
+++ b/lib/data/id/index.js
@@ -1,0 +1,7 @@
+const A = require('./agreeableness')
+const E = require('./extraversion')
+const N = require('./neuroticism')
+const C = require('./conscientiousness')
+const O = require('./openness_to_experience')
+
+module.exports = Object.assign([], [A, E, N, C, O])

--- a/lib/data/id/neuroticism.js
+++ b/lib/data/id/neuroticism.js
@@ -1,0 +1,105 @@
+module.exports = {
+  domain: 'N',
+  title: 'Neuroticism',
+  shortDescription: 'Neuroticism refers to the tendency to experience negative feelings.',
+  description: `Freud originally used the term neurosis to describe a
+condition marked by mental distress, emotional suffering, and an
+inability to cope effectively with the normal demands of life. He
+suggested that everyone shows some signs of neurosis, but that we
+differ in our degree of suffering and our specific symptoms of
+distress. Today neuroticism refers to the tendency to experience
+negative feelings. <br /><br />Those who score high on Neuroticism may
+experience primarily one specific negative feeling such as anxiety,
+anger, or depression, but are likely to experience several of these
+emotions. <br /><br />People high in neuroticism are emotionally reactive. They
+respond emotionally to events that would not affect most people, and
+their reactions tend to be more intense than normal. They are more
+likely to interpret ordinary situations as threatening, and minor
+frustrations as hopelessly difficult. <br /><br />Their negative emotional
+reactions tend to persist for unusually long periods of time, which
+means they are often in a bad mood. These problems in emotional
+regulation can diminish a neurotic's ability to think clearly, make
+decisions, and cope effectively with stress.`,
+  results: [
+    {
+      score: 'low', // do not translate this line
+      text: `Your score on Neuroticism is low, indicating that you are
+exceptionally calm, composed and unflappable. You do not react with
+intense emotions, even to situations that most people would describe
+as stressful.`
+    },
+    {
+      score: 'neutral', // do not translate this line
+      text: `Your score on Neuroticism is average, indicating that your level of
+emotional reactivity is typical of the general population.
+Stressful and frustrating situations are somewhat upsetting to you,
+but you are generally able to get over these feelings and cope with
+these situations.`
+    },
+    {
+      score: 'high', // do not translate this line
+      text: `Your score on Neuroticism is high, indicating that you are easily
+upset, even by what most people consider the normal demands of
+living. People consider you to be sensitive and emotional.`
+    }
+  ],
+  facets: [
+    {
+      facet: 1,
+      title: 'Anxiety',
+      text: `The "fight-or-flight" system of the brain of anxious
+individuals is too easily and too often engaged. Therefore, people who
+are high in anxiety often feel like something dangerous is about to happen.
+They may be afraid of specific situations or be just generally fearful.
+They feel tense, jittery, and nervous. Persons low in Anxiety are generally
+calm and fearless.`
+    },
+    {
+      facet: 2,
+      title: 'Anger',
+      text: `Persons who score high in Anger feel enraged when
+things do not go their way. They are sensitive about being treated fairly
+and feel resentful and bitter when they feel they are being cheated.
+This scale measures the tendency to feel angry; whether or not the
+person expresses annoyance and hostility depends on the individual's
+level on Agreeableness. Low scorers do not get angry often or easily.`
+    },
+    {
+      facet: 3,
+      title: 'Depression',
+      text: `This scale measures the tendency to feel sad, dejected,
+and discouraged. High scorers lack energy and have difficulty initiating
+activities. Low scorers tend to be free from these depressive feelings.`
+    },
+    {
+      facet: 4,
+      title: 'Self-Consciousness',
+      text: `Self-conscious individuals are sensitive
+about what others think of them. Their concern about rejection and
+ridicule cause them to feel shy and uncomfortable around others. They
+are easily embarrassed and often feel ashamed. Their fears that others
+will criticize or make fun of them are exaggerated and unrealistic, but
+their awkwardness and discomfort may make these fears a self-fulfilling
+prophecy. Low scorers, in contrast, do not suffer from the mistaken
+impression that everyone is watching and judging them. They do not feel
+nervous in social situations.`
+    },
+    {
+      facet: 5,
+      title: 'Immoderation',
+      text: `Immoderate individuals feel strong cravings and
+urges that they have have difficulty resisting. They tend to be
+oriented toward short-term pleasures and rewards rather than long-
+term consequences. Low scorers do not experience strong, irresistible
+cravings and consequently do not find themselves tempted to overindulge.`
+    },
+    {
+      facet: 6,
+      title: 'Vulnerability',
+      text: `High scorers on Vulnerability experience
+panic, confusion, and helplessness when under pressure or stress.
+Low scorers feel more poised, confident, and clear-thinking when
+stressed.`
+    }
+  ]
+}

--- a/lib/data/id/neuroticism.js
+++ b/lib/data/id/neuroticism.js
@@ -3,7 +3,7 @@ module.exports = {
   title: 'Neurotisisme',
   shortDescription: 'Neurotisisme mengacu pada kecenderungan untuk mengalami perasaan negatif.',
   description: `Freud awalnya menggunakan istilah neurosis untuk menggambarkan suatu kondisi yang ditandai dengan tekanan mental, penderitaan emosional, dan ketidakmampuan untuk mengatasi secara efektif tuntutan hidup yang normal. Dia menyarankan bahwa setiap orang menunjukkan beberapa tanda neurosis, tetapi kita berbeda dalam tingkat penderitaan dan gejala spesifik kita. Sekarang neurotisisme mengacu pada kecenderungan untuk mengalami perasaan negatif.<br /><br />
-  Mereka yang mendapat skor tinggi pada Neurotisisme mungkin mengalami satu perasaan negatif tertentu yang utama, seperti kecemasan, kemarahan, atau depresi, tetapi cenderung mengalami beberapa dari emosi ini.<br /><br />
+  Mereka yang mendapat nilai tinggi pada Neurotisisme mungkin mengalami satu perasaan negatif tertentu yang utama, seperti kecemasan, kemarahan, atau depresi, tetapi cenderung mengalami beberapa dari emosi ini.<br /><br />
   Orang-orang yang memiliki tingkat neurotisisme tinggi secara emosional reaktif. Mereka merespons secara emosional terhadap peristiwa yang tidak akan mempengaruhi kebanyakan orang, dan reaksi mereka cenderung lebih intens dari biasanya. Mereka lebih cenderung menafsirkan situasi biasa sebagai ancaman, dan frustrasi kecil sebagai hal yang sangat sulit.<br /><br />
   Reaksi emosional negatif mereka cenderung bertahan untuk jangka waktu yang sangat lama, yang berarti mereka sering dalam suasana hati yang buruk. Masalah-masalah dalam pengaturan emosi ini dapat mengurangi kemampuan seorang neurotik untuk berpikir jernih, membuat keputusan, dan mengatasi stres secara efektif.`,
   results: [
@@ -49,7 +49,7 @@ module.exports = {
     {
       facet: 6,
       title: 'Kerentanan',
-      text: `Orang-orang yang mendapat nilai tinggi pada Kerentanan mengalami kepanikan, kebingungan, dan ketidakberdayaan saat berada di bawah tekanan atau stres. Skor rendah merasa lebih tenang, percaya diri, dan berpikir jernih saat stres.`
+      text: `Orang-orang yang mendapat nilai tinggi pada Kerentanan mengalami kepanikan, kebingungan, dan ketidakberdayaan saat berada di bawah tekanan atau stres. Nilai rendah merasa lebih tenang, percaya diri, dan berpikir jernih saat stres.`
     }
   ]
 }

--- a/lib/data/id/neuroticism.js
+++ b/lib/data/id/neuroticism.js
@@ -1,105 +1,55 @@
 module.exports = {
   domain: 'N',
-  title: 'Neuroticism',
-  shortDescription: 'Neuroticism refers to the tendency to experience negative feelings.',
-  description: `Freud originally used the term neurosis to describe a
-condition marked by mental distress, emotional suffering, and an
-inability to cope effectively with the normal demands of life. He
-suggested that everyone shows some signs of neurosis, but that we
-differ in our degree of suffering and our specific symptoms of
-distress. Today neuroticism refers to the tendency to experience
-negative feelings. <br /><br />Those who score high on Neuroticism may
-experience primarily one specific negative feeling such as anxiety,
-anger, or depression, but are likely to experience several of these
-emotions. <br /><br />People high in neuroticism are emotionally reactive. They
-respond emotionally to events that would not affect most people, and
-their reactions tend to be more intense than normal. They are more
-likely to interpret ordinary situations as threatening, and minor
-frustrations as hopelessly difficult. <br /><br />Their negative emotional
-reactions tend to persist for unusually long periods of time, which
-means they are often in a bad mood. These problems in emotional
-regulation can diminish a neurotic's ability to think clearly, make
-decisions, and cope effectively with stress.`,
+  title: 'Neurotisisme',
+  shortDescription: 'Neurotisisme mengacu pada kecenderungan untuk mengalami perasaan negatif.',
+  description: `Freud awalnya menggunakan istilah neurosis untuk menggambarkan suatu kondisi yang ditandai dengan tekanan mental, penderitaan emosional, dan ketidakmampuan untuk mengatasi secara efektif tuntutan hidup yang normal. Dia menyarankan bahwa setiap orang menunjukkan beberapa tanda neurosis, tetapi kita berbeda dalam tingkat penderitaan dan gejala spesifik kita. Sekarang neurotisisme mengacu pada kecenderungan untuk mengalami perasaan negatif.<br /><br />
+  Mereka yang mendapat skor tinggi pada Neurotisisme mungkin mengalami satu perasaan negatif tertentu yang utama, seperti kecemasan, kemarahan, atau depresi, tetapi cenderung mengalami beberapa dari emosi ini.<br /><br />
+  Orang-orang yang memiliki tingkat neurotisisme tinggi secara emosional reaktif. Mereka merespons secara emosional terhadap peristiwa yang tidak akan mempengaruhi kebanyakan orang, dan reaksi mereka cenderung lebih intens dari biasanya. Mereka lebih cenderung menafsirkan situasi biasa sebagai ancaman, dan frustrasi kecil sebagai hal yang sangat sulit.<br /><br />
+  Reaksi emosional negatif mereka cenderung bertahan untuk jangka waktu yang sangat lama, yang berarti mereka sering dalam suasana hati yang buruk. Masalah-masalah dalam pengaturan emosi ini dapat mengurangi kemampuan seorang neurotik untuk berpikir jernih, membuat keputusan, dan mengatasi stres secara efektif.`,
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Your score on Neuroticism is low, indicating that you are
-exceptionally calm, composed and unflappable. You do not react with
-intense emotions, even to situations that most people would describe
-as stressful.`
+      text: `Nilai Anda pada Neurotisisme rendah, yang menunjukkan bahwa Anda sangat tenang dan tak tergoyahkan. Anda tidak bereaksi dengan emosi yang kuat, bahkan terhadap situasi yang kebanyakan orang akan gambarkan sebagai stres.`
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Your score on Neuroticism is average, indicating that your level of
-emotional reactivity is typical of the general population.
-Stressful and frustrating situations are somewhat upsetting to you,
-but you are generally able to get over these feelings and cope with
-these situations.`
+      text: `Nilai Anda pada Neurotisisme adalah rata-rata, yang menunjukkan bahwa tingkat reaktivitas emosional Anda adalah rata-rata populasi umum. Situasi yang membuat stres dan membuat frustrasi agak membuat Anda kesal, tetapi Anda biasanya dapat mengatasi perasaan ini dan mengatasi situasi ini.`
     },
     {
       score: 'high', // do not translate this line
-      text: `Your score on Neuroticism is high, indicating that you are easily
-upset, even by what most people consider the normal demands of
-living. People consider you to be sensitive and emotional.`
+      text: `Nilai Anda pada Neurotisisme tinggi, yang menunjukkan bahwa Anda mudah marah, bahkan oleh apa yang kebanyakan orang anggap sebagai tuntutan hidup yang normal. Orang-orang menganggap Anda sensitif dan emosional.`
     }
   ],
   facets: [
     {
       facet: 1,
-      title: 'Anxiety',
-      text: `The "fight-or-flight" system of the brain of anxious
-individuals is too easily and too often engaged. Therefore, people who
-are high in anxiety often feel like something dangerous is about to happen.
-They may be afraid of specific situations or be just generally fearful.
-They feel tense, jittery, and nervous. Persons low in Anxiety are generally
-calm and fearless.`
+      title: 'Kegelisahan',
+      text: `Sistem "fight-or-flight" (bertarung atau berlari) otak seseorang yang cemas terlalu mudah dan terlalu sering digunakan. Dengan demikian, orang yang memiliki kecemasan tinggi sering merasa seperti sesuatu yang berbahaya akan terjadi. Mereka mungkin takut pada situasi tertentu atau hanya takut pada umumnya. Mereka merasa tegang, gelisah, dan gugup. Orang yang tingkat kecemasannya rendah umumnya tenang dan tidak takut.`
     },
     {
       facet: 2,
-      title: 'Anger',
-      text: `Persons who score high in Anger feel enraged when
-things do not go their way. They are sensitive about being treated fairly
-and feel resentful and bitter when they feel they are being cheated.
-This scale measures the tendency to feel angry; whether or not the
-person expresses annoyance and hostility depends on the individual's
-level on Agreeableness. Low scorers do not get angry often or easily.`
+      title: 'Kemarahan',
+      text: `Orang-orang yang mendapat nilai tinggi dalam Kemarahan merasa marah ketika segala sesuatunya tidak berjalan sesuai keinginan mereka. Mereka sensitif tentang diperlakukan secara adil dan merasa kesal dan pahit ketika mereka merasa dicurangi. Skala ini mengukur kecenderungan untuk merasa marah; apakah orang tersebut mengungkapkan kekesalan dan permusuhan tergantung pada tingkat Agreeableness individu tersebut. Orang-orang yang mendapat nilai rendah tidak sering atau mudah marah.`
     },
     {
       facet: 3,
-      title: 'Depression',
-      text: `This scale measures the tendency to feel sad, dejected,
-and discouraged. High scorers lack energy and have difficulty initiating
-activities. Low scorers tend to be free from these depressive feelings.`
+      title: 'Depresi',
+      text: `Skala ini mengukur kecenderungan untuk merasa sedih, sedih, dan putus asa. Orang-orang yang mendapat nilai tinggi kekurangan energi dan mengalami kesulitan memulai aktivitas. Orang-orang yang mendapat nilai rendah cenderung bebas dari perasaan depresi ini.`
     },
     {
       facet: 4,
-      title: 'Self-Consciousness',
-      text: `Self-conscious individuals are sensitive
-about what others think of them. Their concern about rejection and
-ridicule cause them to feel shy and uncomfortable around others. They
-are easily embarrassed and often feel ashamed. Their fears that others
-will criticize or make fun of them are exaggerated and unrealistic, but
-their awkwardness and discomfort may make these fears a self-fulfilling
-prophecy. Low scorers, in contrast, do not suffer from the mistaken
-impression that everyone is watching and judging them. They do not feel
-nervous in social situations.`
+      title: 'Kesadaran Diri',
+      text: `Individu yang sadar diri sensitif tentang apa yang orang lain pikirkan tentang mereka. Kekhawatiran mereka tentang penolakan dan ejekan menyebabkan mereka merasa malu dan tidak nyaman di sekitar orang lain. Mereka mudah dan sering merasa malu. Ketakutan mereka bahwa orang lain akan mengkritik atau mengolok-olok mereka dibesar-besarkan dan tidak realistis, tetapi kecanggungan dan ketidaknyamanan mereka dapat membuat ketakutan ini menjadi ramalan yang terpenuhi dengan sendirinya. Sebaliknya, orang-orang yang mendapat nilai rendah tidak menderita dari kesan yang salah bahwa semua orang menonton dan menilai mereka. Mereka tidak merasa gugup dalam situasi sosial.`
     },
     {
       facet: 5,
-      title: 'Immoderation',
-      text: `Immoderate individuals feel strong cravings and
-urges that they have have difficulty resisting. They tend to be
-oriented toward short-term pleasures and rewards rather than long-
-term consequences. Low scorers do not experience strong, irresistible
-cravings and consequently do not find themselves tempted to overindulge.`
+      title: 'Ketidaktahanan', // TODO: Cari kata yang lebih baik untuk "Immoderation".
+      text: `Individu yang tidak moderat merasakan keinginan yang kuat dan desakan yang sulit mereka tolak. Mereka cenderung berorientasi pada kesenangan dan penghargaan jangka pendek daripada konsekuensi jangka panjang. Orang-orang yang mendapat nilai rendah tidak mengalami hasrat yang kuat dan tak tertahankan dan akibatnya tidak tergoda untuk memanjakan diri secara berlebihan.`
     },
     {
       facet: 6,
-      title: 'Vulnerability',
-      text: `High scorers on Vulnerability experience
-panic, confusion, and helplessness when under pressure or stress.
-Low scorers feel more poised, confident, and clear-thinking when
-stressed.`
+      title: 'Kerentanan',
+      text: `Orang-orang yang mendapat nilai tinggi pada Kerentanan mengalami kepanikan, kebingungan, dan ketidakberdayaan saat berada di bawah tekanan atau stres. Skor rendah merasa lebih tenang, percaya diri, dan berpikir jernih saat stres.`
     }
   ]
 }

--- a/lib/data/id/neuroticism.js
+++ b/lib/data/id/neuroticism.js
@@ -9,47 +9,47 @@ module.exports = {
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Nilai Anda pada Neurotisisme rendah, yang menunjukkan bahwa Anda sangat tenang dan tak tergoyahkan. Anda tidak bereaksi dengan emosi yang kuat, bahkan terhadap situasi yang kebanyakan orang akan gambarkan sebagai stres.`
+      text: 'Nilai Anda pada Neurotisisme rendah, yang menunjukkan bahwa Anda sangat tenang dan tak tergoyahkan. Anda tidak bereaksi dengan emosi yang kuat, bahkan terhadap situasi yang kebanyakan orang akan gambarkan sebagai stres.'
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Nilai Anda pada Neurotisisme adalah rata-rata, yang menunjukkan bahwa tingkat reaktivitas emosional Anda adalah rata-rata populasi umum. Situasi yang membuat stres dan membuat frustrasi agak membuat Anda kesal, tetapi Anda biasanya dapat mengatasi perasaan ini dan mengatasi situasi ini.`
+      text: 'Nilai Anda pada Neurotisisme adalah rata-rata, yang menunjukkan bahwa tingkat reaktivitas emosional Anda adalah rata-rata populasi umum. Situasi yang membuat stres dan membuat frustrasi agak membuat Anda kesal, tetapi Anda biasanya dapat mengatasi perasaan ini dan mengatasi situasi ini.'
     },
     {
       score: 'high', // do not translate this line
-      text: `Nilai Anda pada Neurotisisme tinggi, yang menunjukkan bahwa Anda mudah marah, bahkan oleh apa yang kebanyakan orang anggap sebagai tuntutan hidup yang normal. Orang-orang menganggap Anda sensitif dan emosional.`
+      text: 'Nilai Anda pada Neurotisisme tinggi, yang menunjukkan bahwa Anda mudah marah, bahkan oleh apa yang kebanyakan orang anggap sebagai tuntutan hidup yang normal. Orang-orang menganggap Anda sensitif dan emosional.'
     }
   ],
   facets: [
     {
       facet: 1,
       title: 'Kegelisahan',
-      text: `Sistem "fight-or-flight" (bertarung atau berlari) otak seseorang yang cemas terlalu mudah dan terlalu sering digunakan. Dengan demikian, orang yang memiliki kecemasan tinggi sering merasa seperti sesuatu yang berbahaya akan terjadi. Mereka mungkin takut pada situasi tertentu atau hanya takut pada umumnya. Mereka merasa tegang, gelisah, dan gugup. Orang yang tingkat kecemasannya rendah umumnya tenang dan tidak takut.`
+      text: 'Sistem "fight-or-flight" (bertarung atau berlari) otak seseorang yang cemas terlalu mudah dan terlalu sering digunakan. Dengan demikian, orang yang memiliki kecemasan tinggi sering merasa seperti sesuatu yang berbahaya akan terjadi. Mereka mungkin takut pada situasi tertentu atau hanya takut pada umumnya. Mereka merasa tegang, gelisah, dan gugup. Orang yang tingkat kecemasannya rendah umumnya tenang dan tidak takut.'
     },
     {
       facet: 2,
       title: 'Kemarahan',
-      text: `Orang-orang yang mendapat nilai tinggi dalam Kemarahan merasa marah ketika segala sesuatunya tidak berjalan sesuai keinginan mereka. Mereka sensitif tentang diperlakukan secara adil dan merasa kesal dan pahit ketika mereka merasa dicurangi. Skala ini mengukur kecenderungan untuk merasa marah; apakah orang tersebut mengungkapkan kekesalan dan permusuhan tergantung pada tingkat Agreeableness individu tersebut. Orang-orang yang mendapat nilai rendah tidak sering atau mudah marah.`
+      text: 'Orang-orang yang mendapat nilai tinggi dalam Kemarahan merasa marah ketika segala sesuatunya tidak berjalan sesuai keinginan mereka. Mereka sensitif tentang diperlakukan secara adil dan merasa kesal dan pahit ketika mereka merasa dicurangi. Skala ini mengukur kecenderungan untuk merasa marah; apakah orang tersebut mengungkapkan kekesalan dan permusuhan tergantung pada tingkat Agreeableness individu tersebut. Orang-orang yang mendapat nilai rendah tidak sering atau mudah marah.'
     },
     {
       facet: 3,
       title: 'Depresi',
-      text: `Skala ini mengukur kecenderungan untuk merasa sedih, sedih, dan putus asa. Orang-orang yang mendapat nilai tinggi kekurangan energi dan mengalami kesulitan memulai aktivitas. Orang-orang yang mendapat nilai rendah cenderung bebas dari perasaan depresi ini.`
+      text: 'Skala ini mengukur kecenderungan untuk merasa sedih, sedih, dan putus asa. Orang-orang yang mendapat nilai tinggi kekurangan energi dan mengalami kesulitan memulai aktivitas. Orang-orang yang mendapat nilai rendah cenderung bebas dari perasaan depresi ini.'
     },
     {
       facet: 4,
       title: 'Kesadaran Diri',
-      text: `Individu yang sadar diri sensitif tentang apa yang orang lain pikirkan tentang mereka. Kekhawatiran mereka tentang penolakan dan ejekan menyebabkan mereka merasa malu dan tidak nyaman di sekitar orang lain. Mereka mudah dan sering merasa malu. Ketakutan mereka bahwa orang lain akan mengkritik atau mengolok-olok mereka dibesar-besarkan dan tidak realistis, tetapi kecanggungan dan ketidaknyamanan mereka dapat membuat ketakutan ini menjadi ramalan yang terpenuhi dengan sendirinya. Sebaliknya, orang-orang yang mendapat nilai rendah tidak menderita dari kesan yang salah bahwa semua orang menonton dan menilai mereka. Mereka tidak merasa gugup dalam situasi sosial.`
+      text: 'Individu yang sadar diri sensitif tentang apa yang orang lain pikirkan tentang mereka. Kekhawatiran mereka tentang penolakan dan ejekan menyebabkan mereka merasa malu dan tidak nyaman di sekitar orang lain. Mereka mudah dan sering merasa malu. Ketakutan mereka bahwa orang lain akan mengkritik atau mengolok-olok mereka dibesar-besarkan dan tidak realistis, tetapi kecanggungan dan ketidaknyamanan mereka dapat membuat ketakutan ini menjadi ramalan yang terpenuhi dengan sendirinya. Sebaliknya, orang-orang yang mendapat nilai rendah tidak menderita dari kesan yang salah bahwa semua orang menonton dan menilai mereka. Mereka tidak merasa gugup dalam situasi sosial.'
     },
     {
       facet: 5,
       title: 'Ketidaktahanan', // TODO: Cari kata yang lebih baik untuk "Immoderation".
-      text: `Individu yang tidak moderat merasakan keinginan yang kuat dan desakan yang sulit mereka tolak. Mereka cenderung berorientasi pada kesenangan dan penghargaan jangka pendek daripada konsekuensi jangka panjang. Orang-orang yang mendapat nilai rendah tidak mengalami hasrat yang kuat dan tak tertahankan dan akibatnya tidak tergoda untuk memanjakan diri secara berlebihan.`
+      text: 'Individu yang tidak moderat merasakan keinginan yang kuat dan desakan yang sulit mereka tolak. Mereka cenderung berorientasi pada kesenangan dan penghargaan jangka pendek daripada konsekuensi jangka panjang. Orang-orang yang mendapat nilai rendah tidak mengalami hasrat yang kuat dan tak tertahankan dan akibatnya tidak tergoda untuk memanjakan diri secara berlebihan.'
     },
     {
       facet: 6,
       title: 'Kerentanan',
-      text: `Orang-orang yang mendapat nilai tinggi pada Kerentanan mengalami kepanikan, kebingungan, dan ketidakberdayaan saat berada di bawah tekanan atau stres. Nilai rendah merasa lebih tenang, percaya diri, dan berpikir jernih saat stres.`
+      text: 'Orang-orang yang mendapat nilai tinggi pada Kerentanan mengalami kepanikan, kebingungan, dan ketidakberdayaan saat berada di bawah tekanan atau stres. Nilai rendah merasa lebih tenang, percaya diri, dan berpikir jernih saat stres.'
     }
   ]
 }

--- a/lib/data/id/openness_to_experience.js
+++ b/lib/data/id/openness_to_experience.js
@@ -1,0 +1,118 @@
+module.exports = {
+  domain: 'O',
+  title: 'Openness To Experience',
+  shortDescription: 'Openness to Experience describes a dimension of cognitive style that distinguishes imaginative, creative people from down-to-earth, conventional people.',
+  description: `Open people are intellectually curious,
+appreciative of art, and sensitive to beauty. They tend to be,
+compared to closed people, more aware of their feelings. They tend to
+think and act in individualistic and nonconforming
+ways. Intellectuals typically score high on Openness to Experience;
+consequently, this factor has also been called Culture or
+Intellect. <br /><br />Nonetheless, Intellect is probably best regarded as one aspect of openness
+to experience. Scores on Openness to Experience are only modestly
+related to years of education and scores on standard intelligent tests.
+<br /><br />
+Another characteristic of the open cognitive style is a facility for thinking
+in symbols and abstractions far removed from concrete experience. Depending on
+the individual's specific intellectual abilities, this symbolic cognition may
+take the form of mathematical, logical, or geometric thinking, artistic and
+metaphorical use of language, music composition or performance, or one of the
+many visual or performing arts.
+<br /><br />
+People with low scores on openness to experience tend to have narrow, common
+interests. They prefer the plain, straightforward, and obvious over the
+complex, ambiguous, and subtle. They may regard the arts and sciences with
+suspicion, regarding these endeavors as abstruse or of no practical use.
+Closed people prefer familiarity over novelty; they are conservative and
+resistant to change.
+<br /><br />
+Openness is often presented as healthier or more mature by psychologists, who
+are often themselves open to experience. However, open and closed styles of
+thinking are useful in different environments. The intellectual style of the
+open person may serve a professor well, but research has shown that closed
+thinking is related to superior job performance in police work, sales, and
+a number of service occupations.`,
+  results: [
+    {
+      score: 'low', // do not translate this line
+      text: `Your score on Openness to Experience is low, indicating you like to think in
+plain and simple terms. Others describe you as down-to-earth, practical,
+and conservative.`
+    },
+    {
+      score: 'neutral', // do not translate this line
+      text: `Your score on Openness to Experience is average, indicating you enjoy
+tradition but are willing to try new things. Your thinking is neither
+simple nor complex. To others you appear to be a well-educated person
+but not an intellectual.`
+    },
+    {
+      score: 'high', // do not translate this line
+      text: `Your score on Openness to Experience is high, indicating you enjoy novelty,
+variety, and change. You are curious, imaginative, and creative.`
+    }
+  ],
+  facets: [
+    {
+      facet: 1,
+      title: 'Imagination',
+      text: `To imaginative individuals, the real world is
+often too plain and ordinary. High scorers on this scale use fantasy as a
+way of creating a richer, more interesting world. Low scorers are on this
+scale are more oriented to facts than fantasy.`
+    },
+    {
+      facet: 2,
+      title: 'Artistic Interests',
+      text: `High scorers on this scale love beauty, both in
+art and in nature. They become easily involved and absorbed in artistic
+and natural events. They are not necessarily artistically trained nor
+talented, although many will be. The defining features of this scale are
+interest in, and appreciation of natural and
+artificial beauty. Low scorers lack aesthetic sensitivity and interest in
+the arts.`
+    },
+    {
+      facet: 3,
+      title: 'Emotionality',
+      text: `Persons high on Emotionality have good access
+to and awareness of their own feelings. Low scorers are less aware of
+their feelings and tend not to express their emotions openly.`
+    },
+    {
+      facet: 4,
+      title: 'Adventurousness',
+      text: `High scorers on adventurousness are eager to
+try new activities, travel to foreign lands, and experience different
+things. They find familiarity and routine boring, and will take a new
+route home just because it is different. Low scorers tend to feel
+uncomfortable with change and prefer familiar routines.`
+    },
+    {
+      facet: 5,
+      title: 'Intellect',
+      text: `Intellect and artistic interests are the two most
+important, central aspects of openness to experience. High scorers on
+Intellect love to play with ideas. They are open-minded to new and unusual
+ideas, and like to debate intellectual issues. They enjoy riddles, puzzles,
+and brain teasers. Low scorers on Intellect prefer dealing with either
+people or things rather than ideas. They regard intellectual exercises as a
+waste of time. Intellect should not be equated with intelligence.
+Intellect is an intellectual style, not an intellectual ability, although
+high scorers on Intellect score slightly higher than low-Intellect
+individuals on standardized intelligence tests.`
+    },
+    {
+      facet: 6,
+      title: 'Liberalism',
+      text: `Psychological liberalism refers to a readiness to
+challenge authority, convention, and traditional values. In its most
+extreme form, psychological liberalism can even represent outright
+hostility toward rules, sympathy for law-breakers, and love of ambiguity,
+chaos, and disorder. Psychological conservatives prefer the security and
+stability brought by conformity to tradition. Psychological liberalism
+and conservatism are not identical to political affiliation, but certainly
+incline individuals toward certain political parties.`
+    }
+  ]
+}

--- a/lib/data/id/openness_to_experience.js
+++ b/lib/data/id/openness_to_experience.js
@@ -1,118 +1,55 @@
 module.exports = {
   domain: 'O',
-  title: 'Openness To Experience',
-  shortDescription: 'Openness to Experience describes a dimension of cognitive style that distinguishes imaginative, creative people from down-to-earth, conventional people.',
-  description: `Open people are intellectually curious,
-appreciative of art, and sensitive to beauty. They tend to be,
-compared to closed people, more aware of their feelings. They tend to
-think and act in individualistic and nonconforming
-ways. Intellectuals typically score high on Openness to Experience;
-consequently, this factor has also been called Culture or
-Intellect. <br /><br />Nonetheless, Intellect is probably best regarded as one aspect of openness
-to experience. Scores on Openness to Experience are only modestly
-related to years of education and scores on standard intelligent tests.
-<br /><br />
-Another characteristic of the open cognitive style is a facility for thinking
-in symbols and abstractions far removed from concrete experience. Depending on
-the individual's specific intellectual abilities, this symbolic cognition may
-take the form of mathematical, logical, or geometric thinking, artistic and
-metaphorical use of language, music composition or performance, or one of the
-many visual or performing arts.
-<br /><br />
-People with low scores on openness to experience tend to have narrow, common
-interests. They prefer the plain, straightforward, and obvious over the
-complex, ambiguous, and subtle. They may regard the arts and sciences with
-suspicion, regarding these endeavors as abstruse or of no practical use.
-Closed people prefer familiarity over novelty; they are conservative and
-resistant to change.
-<br /><br />
-Openness is often presented as healthier or more mature by psychologists, who
-are often themselves open to experience. However, open and closed styles of
-thinking are useful in different environments. The intellectual style of the
-open person may serve a professor well, but research has shown that closed
-thinking is related to superior job performance in police work, sales, and
-a number of service occupations.`,
+  title: 'Keterbukaan terhadap Pengalaman',
+  shortDescription: 'Keterbukaan terhadap Pengalaman menggambarkan dimensi gaya kognitif yang membedakan orang yang imajinatif dan kreatif dari orang yang sederhana dan konvensional.',
+  description: `Orang-orang terbuka ingin tahu secara intelektual, menghargai seni, dan peka terhadap keindahan. Mereka cenderung, dibandingkan dengan orang tertutup, lebih <b> menyadari perasaan mereka. Mereka cenderung berpikir dan bertindak dengan cara yang individualistis dan tidak sesuai. Kaum intelektual biasanya mendapat skor tinggi pada Keterbukaan terhadap Pengalaman; akibatnya, faktor ini juga disebut Budaya atau Intelek.<br /><br />
+  Meskipun demikian, Akal mungkin paling baik dianggap sebagai salah satu aspek Keterbukaan terhadap Pengalaman. Skor pada Keterbukaan terhadap Pengalaman hanya sedikit terkait dengan tahun pendidikan dan skor pada tes kecerdasan standar.<br /><br />
+  Karakteristik lain dari gaya kognitif terbuka adalah fasilitas untuk berpikir dalam simbol dan abstraksi yang jauh dari pengalaman konkret. Bergantung pada kemampuan intelektual spesifik individu, kognisi simbolik ini dapat berbentuk pemikiran matematika, logis, atau geometris, penggunaan bahasa secara artistik dan metaforis, komposisi atau pertunjukan musik, atau salah satu dari banyak seni visual atau pertunjukan.<br /><br />
+  Orang dengan skor rendah pada Keterbukaan terhadap Pengalaman cenderung memiliki <b> minat yang sempit dan sama. Mereka lebih menyukai yang polos, lugas, dan jelas daripada yang rumit, ambigu, dan halus. Mereka mungkin menganggap seni dan sains dengan curiga, menganggap upaya ini sebagai musykil atau tidak berguna secara praktis. Orang tertutup lebih menyukai keakraban daripada hal baru; mereka konservatif dan tahan terhadap perubahan. Keterbukaan sering kali ditampilkan sebagai lebih sehat atau lebih dewasa oleh psikolog, yang seringkali juga terbuka untuk pengalaman. Namun, gaya berpikir terbuka dan tertutup berguna dalam lingkungan yang berbeda. Gaya intelektual orang terbuka mungkin dapat melayani seorang profesor dengan baik, tetapi penelitian telah menunjukkan bahwa pemikiran tertutup terkait dengan kinerja kerja yang unggul dalam pekerjaan polisi, penjualan, dan sejumlah pekerjaan layanan.`,
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Your score on Openness to Experience is low, indicating you like to think in
-plain and simple terms. Others describe you as down-to-earth, practical,
-and conservative.`
+      text: `Nilai Anda pada Keterbukaan terhadap Pengalaman rendah, yang menunjukkan bahwa Anda suka berpikir secara lugas dan sederhana. Orang lain menggambarkan Anda sebagai orang yang sederhana, praktis, dan konservatif.`
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Your score on Openness to Experience is average, indicating you enjoy
-tradition but are willing to try new things. Your thinking is neither
-simple nor complex. To others you appear to be a well-educated person
-but not an intellectual.`
+      text: `Skor Anda pada Keterbukaan terhadap Pengalaman adalah rata-rata, yang menunjukkan Anda menikmati tradisi tetapi bersedia mencoba hal-hal baru. Pemikiran Anda tidak sederhana atau kompleks. Bagi orang lain, Anda tampak seperti orang yang terdidik tetapi bukan intelektual.`
     },
     {
       score: 'high', // do not translate this line
-      text: `Your score on Openness to Experience is high, indicating you enjoy novelty,
-variety, and change. You are curious, imaginative, and creative.`
+      text: `Nilai Anda pada Keterbukaan terhadap Pengalaman tinggi, menunjukkan bahwa Anda menikmati hal baru, variasi, dan perubahan. Anda memiliki sifat ingin tahu, imajinatif, dan kreatif.`
     }
   ],
   facets: [
     {
       facet: 1,
-      title: 'Imagination',
-      text: `To imaginative individuals, the real world is
-often too plain and ordinary. High scorers on this scale use fantasy as a
-way of creating a richer, more interesting world. Low scorers are on this
-scale are more oriented to facts than fantasy.`
+      title: 'Imajinasi',
+      text: `Bagi individu yang imajinatif, dunia nyata seringkali terlalu sederhana dan biasa. Orang-orang yang memiliki nilai tinggi pada skala ini menggunakan fantasi sebagai cara untuk menciptakan dunia yang lebih kaya dan lebih menarik. Orang-orang yang memiliki nilai rendah pada skala ini lebih berorientasi pada fakta daripada fantasi.`
     },
     {
       facet: 2,
-      title: 'Artistic Interests',
-      text: `High scorers on this scale love beauty, both in
-art and in nature. They become easily involved and absorbed in artistic
-and natural events. They are not necessarily artistically trained nor
-talented, although many will be. The defining features of this scale are
-interest in, and appreciation of natural and
-artificial beauty. Low scorers lack aesthetic sensitivity and interest in
-the arts.`
+      title: 'Minat Artistik',
+      text: `Orang-orang yang memiliki skor tinggi pada skala ini menyukai keindahan, baik dalam seni maupun alam. Mereka menjadi mudah terlibat dan terserap dalam peristiwa seni dan alam. Mereka belum tentu terlatih secara artistik atau berbakat, meskipun banyak yang akan melakukannya. Ciri-ciri yang menentukan dari skala ini adalah ketertarikan, dan apresiasi terhadap keindahan alam dan buatan. Orang-orang yang memiliki nilai rendah kurang memiliki kepekaan estetika dan minat pada seni.`
     },
     {
       facet: 3,
-      title: 'Emotionality',
-      text: `Persons high on Emotionality have good access
-to and awareness of their own feelings. Low scorers are less aware of
-their feelings and tend not to express their emotions openly.`
+      title: 'Emosionalitas',
+      text: `Orang-orang yang memiliki Emosionalitas tinggi memiliki akses dan kesadaran yang baik akan perasaan mereka sendiri. Orang-orang yang memiliki nilai rendah kurang menyadari perasaan mereka dan cenderung tidak mengekspresikan emosi mereka secara terbuka.`
     },
     {
       facet: 4,
-      title: 'Adventurousness',
-      text: `High scorers on adventurousness are eager to
-try new activities, travel to foreign lands, and experience different
-things. They find familiarity and routine boring, and will take a new
-route home just because it is different. Low scorers tend to feel
-uncomfortable with change and prefer familiar routines.`
+      title: 'Kepetualangan',
+      text: `Orang-orang yang memiliki nilai tinggi dalam Kepetualangan sangat ingin mencoba aktivitas baru, bepergian ke negeri asing, dan mengalami hal yang berbeda. Mereka menemukan keakraban dan rutinitas yang membosankan, dan akan mengambil jalan baru pulang hanya karena itu berbeda. Orang-orang yang memiliki nilai rendah cenderung merasa tidak nyaman dengan perubahan dan lebih menyukai rutinitas yang sudah biasa.`
     },
     {
       facet: 5,
-      title: 'Intellect',
-      text: `Intellect and artistic interests are the two most
-important, central aspects of openness to experience. High scorers on
-Intellect love to play with ideas. They are open-minded to new and unusual
-ideas, and like to debate intellectual issues. They enjoy riddles, puzzles,
-and brain teasers. Low scorers on Intellect prefer dealing with either
-people or things rather than ideas. They regard intellectual exercises as a
-waste of time. Intellect should not be equated with intelligence.
-Intellect is an intellectual style, not an intellectual ability, although
-high scorers on Intellect score slightly higher than low-Intellect
-individuals on standardized intelligence tests.`
+      title: 'Intelek',
+      text: `Kecerdasan dan minat artistik adalah dua aspek terpenting dari Keterbukaan terhadap Pengalaman. Orang-orang yang memiliki nilai tinggi pada Intelek suka bermain-main dengan ide. Mereka berpikiran terbuka terhadap ide-ide baru dan tidak biasa, dan suka memperdebatkan masalah intelektual. Mereka menyukai teka-teki, teka-teki, dan asah otak. Orang yang mendapat skor rendah pada Akal lebih suka berurusan dengan orang atau benda daripada ide. Mereka menganggap latihan intelektual sebagai pemborosan waktu. Akal tidak boleh disamakan dengan kecerdasan. Akal adalah gaya intelektual, bukan kemampuan intelektual, meskipun skor tinggi pada Kecerdasan mendapat skor sedikit lebih tinggi daripada individu dengan Kecerdasan rendah pada tes kecerdasan standar.`
     },
     {
       facet: 6,
-      title: 'Liberalism',
-      text: `Psychological liberalism refers to a readiness to
-challenge authority, convention, and traditional values. In its most
-extreme form, psychological liberalism can even represent outright
-hostility toward rules, sympathy for law-breakers, and love of ambiguity,
-chaos, and disorder. Psychological conservatives prefer the security and
-stability brought by conformity to tradition. Psychological liberalism
-and conservatism are not identical to political affiliation, but certainly
-incline individuals toward certain political parties.`
+      title: 'Liberalisme',
+      text: `Liberalisme psikologis mengacu pada kesiapan untuk menantang otoritas, konvensi, dan nilai-nilai tradisional. Dalam bentuknya yang paling ekstrem, liberalisme psikologis bahkan dapat mewakili permusuhan langsung terhadap aturan, simpati bagi pelanggar hukum, dan cinta ambiguitas, kekacauan, dan kekacauan. Kaum konservatif psikologis lebih menyukai keamanan dan stabilitas yang dibawa oleh kesesuaian dengan tradisi. Liberalisme psikologis dan konservatisme tidak identik dengan afiliasi politik, tetapi yang pasti mengarahkan individu ke partai politik tertentu.`
     }
   ]
 }

--- a/lib/data/id/openness_to_experience.js
+++ b/lib/data/id/openness_to_experience.js
@@ -2,10 +2,10 @@ module.exports = {
   domain: 'O',
   title: 'Keterbukaan terhadap Pengalaman',
   shortDescription: 'Keterbukaan terhadap Pengalaman menggambarkan dimensi gaya kognitif yang membedakan orang yang imajinatif dan kreatif dari orang yang sederhana dan konvensional.',
-  description: `Orang-orang terbuka ingin tahu secara intelektual, menghargai seni, dan peka terhadap keindahan. Mereka cenderung, dibandingkan dengan orang tertutup, lebih <b> menyadari perasaan mereka. Mereka cenderung berpikir dan bertindak dengan cara yang individualistis dan tidak sesuai. Kaum intelektual biasanya mendapat skor tinggi pada Keterbukaan terhadap Pengalaman; akibatnya, faktor ini juga disebut Budaya atau Intelek.<br /><br />
-  Meskipun demikian, Akal mungkin paling baik dianggap sebagai salah satu aspek Keterbukaan terhadap Pengalaman. Skor pada Keterbukaan terhadap Pengalaman hanya sedikit terkait dengan tahun pendidikan dan skor pada tes kecerdasan standar.<br /><br />
+  description: `Orang-orang terbuka ingin tahu secara intelektual, menghargai seni, dan peka terhadap keindahan. Mereka cenderung, dibandingkan dengan orang tertutup, lebih menyadari perasaan mereka. Mereka cenderung berpikir dan bertindak dengan cara yang individualistis dan tidak sesuai. Kaum intelektual biasanya mendapat nilai tinggi pada Keterbukaan terhadap Pengalaman. Akibatnya, faktor ini juga disebut Budaya atau Intelek.<br /><br />
+  Meskipun demikian, Intelek mungkin paling baik dianggap sebagai salah satu aspek Keterbukaan terhadap Pengalaman. Nilai pada Keterbukaan terhadap Pengalaman hanya sedikit terkait dengan tahun pendidikan dan nilai pada tes kecerdasan standar.<br /><br />
   Karakteristik lain dari gaya kognitif terbuka adalah fasilitas untuk berpikir dalam simbol dan abstraksi yang jauh dari pengalaman konkret. Bergantung pada kemampuan intelektual spesifik individu, kognisi simbolik ini dapat berbentuk pemikiran matematika, logis, atau geometris, penggunaan bahasa secara artistik dan metaforis, komposisi atau pertunjukan musik, atau salah satu dari banyak seni visual atau pertunjukan.<br /><br />
-  Orang dengan skor rendah pada Keterbukaan terhadap Pengalaman cenderung memiliki <b> minat yang sempit dan sama. Mereka lebih menyukai yang polos, lugas, dan jelas daripada yang rumit, ambigu, dan halus. Mereka mungkin menganggap seni dan sains dengan curiga, menganggap upaya ini sebagai musykil atau tidak berguna secara praktis. Orang tertutup lebih menyukai keakraban daripada hal baru; mereka konservatif dan tahan terhadap perubahan. Keterbukaan sering kali ditampilkan sebagai lebih sehat atau lebih dewasa oleh psikolog, yang seringkali juga terbuka untuk pengalaman. Namun, gaya berpikir terbuka dan tertutup berguna dalam lingkungan yang berbeda. Gaya intelektual orang terbuka mungkin dapat melayani seorang profesor dengan baik, tetapi penelitian telah menunjukkan bahwa pemikiran tertutup terkait dengan kinerja kerja yang unggul dalam pekerjaan polisi, penjualan, dan sejumlah pekerjaan layanan.`,
+  Orang dengan nilai rendah pada Keterbukaan terhadap Pengalaman cenderung memiliki minat yang sempit dan sama. Mereka lebih menyukai yang polos, lugas, dan jelas,daripada yang rumit, ambigu, dan halus. Mereka mungkin menganggap seni dan sains dengan curiga, menganggap upaya ini sebagai muskil atau tidak berguna secara praktis. Orang tertutup lebih menyukai keakraban daripada hal baru; mereka konservatif dan tahan terhadap perubahan. Keterbukaan sering kali ditampilkan sebagai lebih sehat atau lebih dewasa oleh psikolog, yang seringkali juga terbuka untuk pengalaman. Namun, gaya berpikir terbuka dan tertutup berguna dalam lingkungan yang berbeda. Gaya intelektual orang terbuka mungkin dapat melayani seorang profesor dengan baik, tetapi penelitian telah menunjukkan bahwa pemikiran tertutup terkait dengan kinerja kerja yang unggul dalam pekerjaan polisi, penjualan, dan sejumlah pekerjaan layanan.`,
   results: [
     {
       score: 'low', // do not translate this line
@@ -24,27 +24,27 @@ module.exports = {
     {
       facet: 1,
       title: 'Imajinasi',
-      text: `Bagi individu yang imajinatif, dunia nyata seringkali terlalu sederhana dan biasa. Orang-orang yang memiliki nilai tinggi pada skala ini menggunakan fantasi sebagai cara untuk menciptakan dunia yang lebih kaya dan lebih menarik. Orang-orang yang memiliki nilai rendah pada skala ini lebih berorientasi pada fakta daripada fantasi.`
+      text: `Bagi individu yang imajinatif, dunia nyata seringkali terlalu sederhana dan biasa. Orang-orang yang mendapat nilai tinggi pada skala ini menggunakan fantasi sebagai cara untuk menciptakan dunia yang lebih kaya dan lebih menarik. Orang-orang yang mendapat nilai rendah pada skala ini lebih berorientasi pada fakta daripada fantasi.`
     },
     {
       facet: 2,
       title: 'Minat Artistik',
-      text: `Orang-orang yang memiliki skor tinggi pada skala ini menyukai keindahan, baik dalam seni maupun alam. Mereka menjadi mudah terlibat dan terserap dalam peristiwa seni dan alam. Mereka belum tentu terlatih secara artistik atau berbakat, meskipun banyak yang akan melakukannya. Ciri-ciri yang menentukan dari skala ini adalah ketertarikan, dan apresiasi terhadap keindahan alam dan buatan. Orang-orang yang memiliki nilai rendah kurang memiliki kepekaan estetika dan minat pada seni.`
+      text: `Orang-orang yang mendapat nilai tinggi pada skala ini menyukai keindahan, baik dalam seni maupun alam. Mereka menjadi mudah terlibat dan terserap dalam peristiwa seni dan alam. Mereka belum tentu terlatih secara artistik atau berbakat, meskipun banyak yang akan melakukannya. Ciri-ciri yang menentukan dari skala ini adalah ketertarikan, dan apresiasi terhadap keindahan alam dan buatan. Orang-orang yang mendapat nilai rendah kurang memiliki kepekaan estetika dan minat pada seni.`
     },
     {
       facet: 3,
       title: 'Emosionalitas',
-      text: `Orang-orang yang memiliki Emosionalitas tinggi memiliki akses dan kesadaran yang baik akan perasaan mereka sendiri. Orang-orang yang memiliki nilai rendah kurang menyadari perasaan mereka dan cenderung tidak mengekspresikan emosi mereka secara terbuka.`
+      text: `Orang-orang yang mendapat Emosionalitas tinggi memiliki akses dan kesadaran yang baik akan perasaan mereka sendiri. Orang-orang yang mendapat nilai rendah kurang menyadari perasaan mereka dan cenderung tidak mengekspresikan emosi mereka secara terbuka.`
     },
     {
       facet: 4,
       title: 'Kepetualangan',
-      text: `Orang-orang yang memiliki nilai tinggi dalam Kepetualangan sangat ingin mencoba aktivitas baru, bepergian ke negeri asing, dan mengalami hal yang berbeda. Mereka menemukan keakraban dan rutinitas yang membosankan, dan akan mengambil jalan baru pulang hanya karena itu berbeda. Orang-orang yang memiliki nilai rendah cenderung merasa tidak nyaman dengan perubahan dan lebih menyukai rutinitas yang sudah biasa.`
+      text: `Orang-orang yang mendapat nilai tinggi dalam Kepetualangan sangat ingin mencoba aktivitas baru, bepergian ke negeri asing, dan mengalami hal yang berbeda. Mereka menemukan keakraban dan rutinitas yang membosankan, dan akan mengambil jalan baru pulang hanya karena itu berbeda. Orang-orang yang mendapat nilai rendah cenderung merasa tidak nyaman dengan perubahan dan lebih menyukai rutinitas yang sudah biasa.`
     },
     {
       facet: 5,
       title: 'Intelek',
-      text: `Kecerdasan dan minat artistik adalah dua aspek terpenting dari Keterbukaan terhadap Pengalaman. Orang-orang yang memiliki nilai tinggi pada Intelek suka bermain-main dengan ide. Mereka berpikiran terbuka terhadap ide-ide baru dan tidak biasa, dan suka memperdebatkan masalah intelektual. Mereka menyukai teka-teki, teka-teki, dan asah otak. Orang yang mendapat skor rendah pada Akal lebih suka berurusan dengan orang atau benda daripada ide. Mereka menganggap latihan intelektual sebagai pemborosan waktu. Akal tidak boleh disamakan dengan kecerdasan. Akal adalah gaya intelektual, bukan kemampuan intelektual, meskipun skor tinggi pada Kecerdasan mendapat skor sedikit lebih tinggi daripada individu dengan Kecerdasan rendah pada tes kecerdasan standar.`
+      text: `Kecerdasan dan minat artistik adalah dua aspek terpenting dari Keterbukaan terhadap Pengalaman. Orang-orang yang mendapat nilai tinggi pada Intelek suka bermain-main dengan ide. Mereka berpikiran terbuka terhadap ide-ide baru dan tidak biasa, dan suka memperdebatkan masalah intelektual. Mereka menyukai teka-teki, teka-teki, dan asah otak. Orang yang mendapat nilai rendah pada Intelek lebih suka berurusan dengan orang atau benda daripada ide. Mereka menganggap latihan intelektual sebagai pemborosan waktu. Intelek tidak boleh disamakan dengan kecerdasan. Intelek adalah gaya intelektual, bukan kemampuan intelektual, meskipun nilai tinggi pada Kecerdasan mendapat nilai sedikit lebih tinggi daripada individu dengan Kecerdasan rendah pada tes kecerdasan standar.`
     },
     {
       facet: 6,

--- a/lib/data/id/openness_to_experience.js
+++ b/lib/data/id/openness_to_experience.js
@@ -9,47 +9,47 @@ module.exports = {
   results: [
     {
       score: 'low', // do not translate this line
-      text: `Nilai Anda pada Keterbukaan terhadap Pengalaman rendah, yang menunjukkan bahwa Anda suka berpikir secara lugas dan sederhana. Orang lain menggambarkan Anda sebagai orang yang sederhana, praktis, dan konservatif.`
+      text: 'Nilai Anda pada Keterbukaan terhadap Pengalaman rendah, yang menunjukkan bahwa Anda suka berpikir secara lugas dan sederhana. Orang lain menggambarkan Anda sebagai orang yang sederhana, praktis, dan konservatif.'
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Nilai Anda pada Keterbukaan terhadap Pengalaman adalah rata-rata, yang menunjukkan Anda menikmati tradisi tetapi bersedia mencoba hal-hal baru. Pemikiran Anda tidak sederhana atau kompleks. Bagi orang lain, Anda tampak seperti orang yang terdidik tetapi bukan intelektual.`
+      text: 'Nilai Anda pada Keterbukaan terhadap Pengalaman adalah rata-rata, yang menunjukkan Anda menikmati tradisi tetapi bersedia mencoba hal-hal baru. Pemikiran Anda tidak sederhana atau kompleks. Bagi orang lain, Anda tampak seperti orang yang terdidik tetapi bukan intelektual.'
     },
     {
       score: 'high', // do not translate this line
-      text: `Nilai Anda pada Keterbukaan terhadap Pengalaman tinggi, menunjukkan bahwa Anda menikmati hal baru, variasi, dan perubahan. Anda memiliki sifat ingin tahu, imajinatif, dan kreatif.`
+      text: 'Nilai Anda pada Keterbukaan terhadap Pengalaman tinggi, menunjukkan bahwa Anda menikmati hal baru, variasi, dan perubahan. Anda memiliki sifat ingin tahu, imajinatif, dan kreatif.'
     }
   ],
   facets: [
     {
       facet: 1,
       title: 'Imajinasi',
-      text: `Bagi individu yang imajinatif, dunia nyata seringkali terlalu sederhana dan biasa. Orang-orang yang mendapat nilai tinggi pada skala ini menggunakan fantasi sebagai cara untuk menciptakan dunia yang lebih kaya dan lebih menarik. Orang-orang yang mendapat nilai rendah pada skala ini lebih berorientasi pada fakta daripada fantasi.`
+      text: 'Bagi individu yang imajinatif, dunia nyata seringkali terlalu sederhana dan biasa. Orang-orang yang mendapat nilai tinggi pada skala ini menggunakan fantasi sebagai cara untuk menciptakan dunia yang lebih kaya dan lebih menarik. Orang-orang yang mendapat nilai rendah pada skala ini lebih berorientasi pada fakta daripada fantasi.'
     },
     {
       facet: 2,
       title: 'Minat Artistik',
-      text: `Orang-orang yang mendapat nilai tinggi pada skala ini menyukai keindahan, baik dalam seni maupun alam. Mereka menjadi mudah terlibat dan terserap dalam peristiwa seni dan alam. Mereka belum tentu terlatih secara artistik atau berbakat, meskipun banyak yang akan melakukannya. Ciri-ciri yang menentukan dari skala ini adalah ketertarikan, dan apresiasi terhadap keindahan alam dan buatan. Orang-orang yang mendapat nilai rendah kurang memiliki kepekaan estetika dan minat pada seni.`
+      text: 'Orang-orang yang mendapat nilai tinggi pada skala ini menyukai keindahan, baik dalam seni maupun alam. Mereka menjadi mudah terlibat dan terserap dalam peristiwa seni dan alam. Mereka belum tentu terlatih secara artistik atau berbakat, meskipun banyak yang akan melakukannya. Ciri-ciri yang menentukan dari skala ini adalah ketertarikan, dan apresiasi terhadap keindahan alam dan buatan. Orang-orang yang mendapat nilai rendah kurang memiliki kepekaan estetika dan minat pada seni.'
     },
     {
       facet: 3,
       title: 'Emosionalitas',
-      text: `Orang-orang yang mendapat Emosionalitas tinggi memiliki akses dan kesadaran yang baik akan perasaan mereka sendiri. Orang-orang yang mendapat nilai rendah kurang menyadari perasaan mereka dan cenderung tidak mengekspresikan emosi mereka secara terbuka.`
+      text: 'Orang-orang yang mendapat Emosionalitas tinggi memiliki akses dan kesadaran yang baik akan perasaan mereka sendiri. Orang-orang yang mendapat nilai rendah kurang menyadari perasaan mereka dan cenderung tidak mengekspresikan emosi mereka secara terbuka.'
     },
     {
       facet: 4,
       title: 'Kepetualangan',
-      text: `Orang-orang yang mendapat nilai tinggi dalam Kepetualangan sangat ingin mencoba aktivitas baru, bepergian ke negeri asing, dan mengalami hal yang berbeda. Mereka menemukan keakraban dan rutinitas yang membosankan, dan akan mengambil jalan baru pulang hanya karena itu berbeda. Orang-orang yang mendapat nilai rendah cenderung merasa tidak nyaman dengan perubahan dan lebih menyukai rutinitas yang sudah biasa.`
+      text: 'Orang-orang yang mendapat nilai tinggi dalam Kepetualangan sangat ingin mencoba aktivitas baru, bepergian ke negeri asing, dan mengalami hal yang berbeda. Mereka menemukan keakraban dan rutinitas yang membosankan, dan akan mengambil jalan baru pulang hanya karena itu berbeda. Orang-orang yang mendapat nilai rendah cenderung merasa tidak nyaman dengan perubahan dan lebih menyukai rutinitas yang sudah biasa.'
     },
     {
       facet: 5,
       title: 'Intelek',
-      text: `Kecerdasan dan minat artistik adalah dua aspek terpenting dari Keterbukaan terhadap Pengalaman. Orang-orang yang mendapat nilai tinggi pada Intelek suka bermain-main dengan ide. Mereka berpikiran terbuka terhadap ide-ide baru dan tidak biasa, dan suka memperdebatkan masalah intelektual. Mereka menyukai teka-teki, teka-teki, dan asah otak. Orang yang mendapat nilai rendah pada Intelek lebih suka berurusan dengan orang atau benda daripada ide. Mereka menganggap latihan intelektual sebagai pemborosan waktu. Intelek tidak boleh disamakan dengan kecerdasan. Intelek adalah gaya intelektual, bukan kemampuan intelektual, meskipun nilai tinggi pada Kecerdasan mendapat nilai sedikit lebih tinggi daripada individu dengan Kecerdasan rendah pada tes kecerdasan standar.`
+      text: 'Kecerdasan dan minat artistik adalah dua aspek terpenting dari Keterbukaan terhadap Pengalaman. Orang-orang yang mendapat nilai tinggi pada Intelek suka bermain-main dengan ide. Mereka berpikiran terbuka terhadap ide-ide baru dan tidak biasa, dan suka memperdebatkan masalah intelektual. Mereka menyukai teka-teki, teka-teki, dan asah otak. Orang yang mendapat nilai rendah pada Intelek lebih suka berurusan dengan orang atau benda daripada ide. Mereka menganggap latihan intelektual sebagai pemborosan waktu. Intelek tidak boleh disamakan dengan kecerdasan. Intelek adalah gaya intelektual, bukan kemampuan intelektual, meskipun nilai tinggi pada Kecerdasan mendapat nilai sedikit lebih tinggi daripada individu dengan Kecerdasan rendah pada tes kecerdasan standar.'
     },
     {
       facet: 6,
       title: 'Liberalisme',
-      text: `Liberalisme psikologis mengacu pada kesiapan untuk menantang otoritas, konvensi, dan nilai-nilai tradisional. Dalam bentuknya yang paling ekstrem, liberalisme psikologis bahkan dapat mewakili permusuhan langsung terhadap aturan, simpati bagi pelanggar hukum, dan cinta ambiguitas, kekacauan, dan kekacauan. Kaum konservatif psikologis lebih menyukai keamanan dan stabilitas yang dibawa oleh kesesuaian dengan tradisi. Liberalisme psikologis dan konservatisme tidak identik dengan afiliasi politik, tetapi yang pasti mengarahkan individu ke partai politik tertentu.`
+      text: 'Liberalisme psikologis mengacu pada kesiapan untuk menantang otoritas, konvensi, dan nilai-nilai tradisional. Dalam bentuknya yang paling ekstrem, liberalisme psikologis bahkan dapat mewakili permusuhan langsung terhadap aturan, simpati bagi pelanggar hukum, dan cinta ambiguitas, kekacauan, dan kekacauan. Kaum konservatif psikologis lebih menyukai keamanan dan stabilitas yang dibawa oleh kesesuaian dengan tradisi. Liberalisme psikologis dan konservatisme tidak identik dengan afiliasi politik, tetapi yang pasti mengarahkan individu ke partai politik tertentu.'
     }
   ]
 }

--- a/lib/data/id/openness_to_experience.js
+++ b/lib/data/id/openness_to_experience.js
@@ -13,7 +13,7 @@ module.exports = {
     },
     {
       score: 'neutral', // do not translate this line
-      text: `Skor Anda pada Keterbukaan terhadap Pengalaman adalah rata-rata, yang menunjukkan Anda menikmati tradisi tetapi bersedia mencoba hal-hal baru. Pemikiran Anda tidak sederhana atau kompleks. Bagi orang lain, Anda tampak seperti orang yang terdidik tetapi bukan intelektual.`
+      text: `Nilai Anda pada Keterbukaan terhadap Pengalaman adalah rata-rata, yang menunjukkan Anda menikmati tradisi tetapi bersedia mencoba hal-hal baru. Pemikiran Anda tidak sederhana atau kompleks. Bagi orang lain, Anda tampak seperti orang yang terdidik tetapi bukan intelektual.`
     },
     {
       score: 'high', // do not translate this line

--- a/lib/data/languages.json
+++ b/lib/data/languages.json
@@ -50,5 +50,9 @@
   {
     "id": "pt-br",
     "text": "Portuguese Brazilian"
+  },
+  {
+    "id": "id",
+    "text": "Indonesian"
   }
 ]


### PR DESCRIPTION
This is one of the three PRs I made to update the Indonesian translation of the https://bigfive-test.com/. 

- rubynor/bigfive-web#92
- Alheimsins/b5-result-text#181
- Alheimsins/b5-johnson-120-ipip-neo-pi-r#201

I used this service for an assignment, and as a native, A few days ago, I saw that the translation are not prefect and incomplete. I decided to finish it all and fix it all, backed with a decent amount of literature.

This translation is consistent with the website's translation linked above. 

When doing this PR, I removed the 80-width newlines (or that's what I called it) to make it easier for me to translate. What I think is that this would be entered as the content of the HTML elements, so within my knowledge, these newlines may be replaced with other whitespace, such as a space. Please tell me if this is a must.